### PR TITLE
IAM 1Password - Added line to check SCIM bridge status

### DIFF
--- a/connection-guides/iam/1password.mdx
+++ b/connection-guides/iam/1password.mdx
@@ -15,7 +15,8 @@ If you've been directed to StackOne to integrate with 1Password, the following s
 1Password requires account holders to deploy an independent SCIM Bridge to support User data and provisioning via API.
 
 Learn more about the setup requirements and deployment process in [1Password Support](https://support.1password.com/scim/). An Identity Provider (IDP) is not required to configure this integration, but note that the SCIM Bridge setup may vary for connection with different IDPs.
-    
+
+Your SCIM Bridge must be fully configured for this integration. You can check the status of your SCIM bridge at `your-scim-bridge-url/app/status`.
 
 ## Enable 1Password User Provisioning
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a requirement for full SCIM Bridge configuration for 1Password integration.
	- Added a method for users to check the SCIM Bridge status via a specific URL. 

- **Documentation**
	- Updated connection guides to clarify the integration process and provide instructions for verifying SCIM Bridge status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->