### PR TITLE
Update: Added one more scopes to the required list for cornerstone

### DIFF
--- a/connection-guides/ats/cornerstone.mdx
+++ b/connection-guides/ats/cornerstone.mdx
@@ -46,6 +46,7 @@ If you've been directed to StackOne to integrate with Cornerstone, the following
         <li>vw_rpt_requisition:read</li>
         <li>vw_rpt_job_requisition_local:read</li>
         <li>vw_rpt_applicant_interview_management:read</li>
+        <li>vw_rpt_job_requisition_applicant_status_local:read</li>
        </ol>
     </Step>
 


### PR DESCRIPTION
We have recently fixed interview_stages bug so we need one more scope to get all interview_stages.
Updated the doc for required list of scopes. 

![image](https://github.com/user-attachments/assets/71ebd242-b5b7-4d0a-9dfb-7292eedcf162)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the "Cornerstone" integration guide with additional instructions for using the StackOne Hub.
	- Added a warning about the need for Admin privileges on the Cornerstone account.
	- Introduced a new required scope for the application to enhance integration capabilities.

- **Documentation**
	- Improved clarity and completeness of integration instructions without altering existing steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->