### PR TITLE
updated sap naming

### DIFF
--- a/connection-guides/lms/sapsuccessfactors.mdx
+++ b/connection-guides/lms/sapsuccessfactors.mdx
@@ -21,7 +21,7 @@ If you've been directed to StackOne to integrate with SAP SuccessFactors, the fo
 
     For example, if your domain was `https://pmsalesdemo8.successfactors.com/xyz`, you would use `https://pmsalesdemo8.successfactors.com`.
 
-    Use this value as the `API Server` value when connecting SAP SuccessFactors to StackOne.
+    Use this value as the `Domain URL` value when connecting SAP SuccessFactors to StackOne.
   </Step>
 </Steps>
 
@@ -39,6 +39,8 @@ If you've been directed to StackOne to integrate with SAP SuccessFactors, the fo
           <img className='rounded-md' style={{ margin: '0 auto', border: '1px solid #efefef' }} alt="Learning Server Example" src="/images/sapsuccessfactors/image10.png" />
         </Frame>
       In this case: https://sfcpart000906.scdemo.successfactors.com/ is the access point.
+
+      Use this value as the `Learning Domain URL` value when connecting SAP SuccessFactors to StackOne.
       </Step>
   </Steps>  
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated terminology in the "SAP SuccessFactors" guide for clarity, replacing "API Server" with "Domain URL."
	- Added instruction to use "Learning Domain URL" for connecting SAP SuccessFactors to StackOne.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->