### PR TITLE
[ENG-6220] ATS Workday E2E Assessment update statement

### DIFF
--- a/integration-configuration-concepts/ats/workday_e2e_assessment.mdx
+++ b/integration-configuration-concepts/ats/workday_e2e_assessment.mdx
@@ -79,7 +79,7 @@ import IntegrationFooter from "/snippets/integration-footer.mdx";
   </Step>
 
   <Step title="Use of Assessment Status ID">
-    Please ensure that the Assessment Status ID is set to `Invited`, regardless of the status name provided
+    The Assessment Status ID is used to send the assessment invite notification, so please ensure it is set to `Invited` regardless of the status name provided.
     <Frame>
       <img className='rounded-md' style={{ margin: '0 auto', border: '1px solid #efefef' }} alt="Assessment Status ID" src="/images/workday-assessment/Assessment_status_3.png" />
     </Frame>


### PR DESCRIPTION
## Context
- Single sentence update as per the https://stackonehq.atlassian.net/browse/ENG-6220?focusedCommentId=15063


![image](https://github.com/user-attachments/assets/c58278aa-5362-466e-a3b9-3d8832608c0a)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Clarified instructions on managing assessment categories, tests, and statuses in the "Workday E2E Assessment" document.
	- Enhanced explanation regarding the importance of the Assessment Status ID for sending assessment invite notifications.
	- Maintained the overall structure and flow of the document for user guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->