### PR TITLE
Fix Workday Auth Web Service URL

### DIFF
--- a/connection-guides/ats/workday.mdx
+++ b/connection-guides/ats/workday.mdx
@@ -48,7 +48,7 @@ import IntegrationFooter from "/snippets/integration-footer.mdx";
       <img className='rounded-md' style={{ margin: '0 auto', border: '1px solid #efefef' }} alt="WSDL Service" src="/images/workday/image4.png" />
     </Frame>
 
-    Copy everything before `service` in the location attribute. In the example tenant above, this would be `https://wd2-impl-services1.workday.com/ccx` but it may be different for your tenant (e.g., `https://wd5-services1.myworkday.com/ccx`).
+    Copy everything before `service` in the location attribute. In the example tenant above, this would be `wd2-impl-services1.workday.com/ccx` but it may be different for your tenant (e.g., `wd5-services1.myworkday.com/ccx`).
   </Step>
 </Steps>
 

--- a/connection-guides/lms/workdaylearning.mdx
+++ b/connection-guides/lms/workdaylearning.mdx
@@ -48,7 +48,7 @@ import IntegrationFooter from "/snippets/integration-footer.mdx";
       <img className='rounded-md' style={{ margin: '0 auto', border: '1px solid #efefef' }} alt="WSDL Service" src="/images/workday/image11.png" />
     </Frame>
 
-    Copy everything before `service` in the location attribute. In the example tenant above, this would be `https://wd2-impl-services1.workday.com/ccx` but it may be different for your tenant (e.g., `https://wd5-services1.myworkday.com/ccx`).
+    Copy everything before `service` in the location attribute. In the example tenant above, this would be `wd2-impl-services1.workday.com/ccx` but it may be different for your tenant (e.g., `wd5-services1.myworkday.com/ccx`).
   </Step>
 </Steps>
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated Workday connection guide instructions for copying location attributes
	- Simplified URL example by removing `https://` prefix in both ATS and Learning integration guides

<!-- end of auto-generated comment: release notes by coderabbit.ai -->