### PR TITLE
Added IAM Dropxbox Sign plan req

### DIFF
--- a/connection-guides/iam/dropboxsign.mdx
+++ b/connection-guides/iam/dropboxsign.mdx
@@ -6,9 +6,12 @@ description: "If you have been directed to StackOne to integrate with Dropbox Si
 import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
-  The following guidance assumes you have Admin privileges for your Dropbox Sign
-  account.
+  The following guidance assumes you have Admin privileges for your Dropbox Sign account.
 </Warning>
+
+<Info>
+  This integration requires the Dropbox Sign [Standard plan](https://sign.dropbox.com/products/dropbox-sign/pricing), or a higher-tier plan.
+</Info>
 
 ## Generating an API Key
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added an informational note indicating that the Dropbox Sign integration requires the Standard plan or a higher-tier plan.
  - Enhanced the presentation of warning messages by refining the formatting for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->