### PR TITLE
workday learning: updated url path

### DIFF
--- a/connection-guides/lms/workdaylearning.mdx
+++ b/connection-guides/lms/workdaylearning.mdx
@@ -178,7 +178,7 @@ import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Steps>
   <Step title="Download Scorm Course Blocker and Upload to Workday">
-   Download this file <a href="ttps://mintlify.s3-us-west-1.amazonaws.com/stackone-hub/assets/workday-scorm-course.zip">workday-scorm-course.zip</a>.
+   Download this file <a href="https://mintlify.s3-us-west-1.amazonaws.com/stackone-hub/assets/workday-scorm-course.zip">workday-scorm-course.zip</a>.
 
    In the Workday UI, search View Media > Create > Media Document Upload Create > Attach File and click Ok.
     <Frame>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected a broken hyperlink in the course download guide to ensure users can access the "workday-scorm-course.zip" file without issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->