### PR TITLE
fix: tile size

### DIFF
--- a/snippets/integration-tile.mdx
+++ b/snippets/integration-tile.mdx
@@ -2,7 +2,7 @@ export const IntegrationTile = ({ logo, title, link }) => (
   <a href={link}>
     <div style={{ display: 'flex', alignItems: 'center', height: '50px' }}>
       <div>
-        <img src={logo} alt={title} width="25" height="25"/>
+        <img src={logo} alt={title} style={{ width: '25px', height: '25px' }}/>
       </div>
       <div style={{ paddingLeft: '8px', fontWeight: '400', fontSize: '14px', fontFamily: '-apple-system, "system-ui", "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji"' }}>
         <span>{title}</span>


### PR DESCRIPTION
<img width="2182" height="1293" alt="image" src="https://github.com/user-attachments/assets/7881cc06-6cc4-4410-875d-7c394045bb81" />

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Sets IntegrationTile logos to a fixed 25px using inline styles to avoid CSS overrides and keep sizes consistent.

<!-- End of auto-generated description by cubic. -->

