### PR TITLE
Removed HRIS Workday Job Requisitions permission requirement

### DIFF
--- a/connection-guides/hris/workday_OAuth2.mdx
+++ b/connection-guides/hris/workday_OAuth2.mdx
@@ -122,7 +122,6 @@ import IntegrationFooter from "/snippets/integration-footer.mdx";
     <Info>
       Please note that Security Group Permissions can be customized within a Workday organization, and this list does not account for such customizations.
     </Info>
-    - Job Requisition Data
     - Job Information
     - Job Profile: View
     - **Manage:**


### PR DESCRIPTION
HRIS Jobs previously used Job Requisitions data, but is now fetching Positions data
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Removed “Job Requisition Data” from the Workday HRIS OAuth2 permission list because Jobs now use Positions data. This avoids unnecessary access and clarifies the correct setup permissions.

<!-- End of auto-generated description by cubic. -->

