### PR TITLE
fix:added scopes to linkedin hub docs

### DIFF
--- a/connection-guides/lms/linkedinlearning.mdx
+++ b/connection-guides/lms/linkedinlearning.mdx
@@ -32,7 +32,7 @@ description: "If you've been directed to StackOne to integrate with Linkedin Lea
     Expand the `Generate LinkedIn Learning REST API Application` section.
     Click `Add application`.
     Complete the form, explaining how the integration will be used.
-    Select Content for the Choose keys option
+    Select `Content` and `Reporting` for the Choose keys option
 
     <Frame>
       <img className='rounded-md' style={{ margin: '0 auto', border: '1px solid #efefef' }} alt="Dropdown Menu" src="/images/linkedinlearning/image2.png" />


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Updated the LinkedIn Learning setup docs to tell users to select both Content and Reporting keys when creating the REST API application. This ensures the required scopes are requested during app setup.

<!-- End of auto-generated description by cubic. -->

