### PR TITLE
[INT-6508] ATS Bullhorn Assess/BG Check T2 Doc Improvements

### DIFF
--- a/integration-configuration-concepts/ats/bullhorn-assessment-background-check.mdx
+++ b/integration-configuration-concepts/ats/bullhorn-assessment-background-check.mdx
@@ -1,54 +1,55 @@
 ---
 title: "Bullhorn Assessment or Background Check"
-description: "To successfully send test notifications from Bullhorn, follow these steps in your Bullhorn account, and complete the necessary actions."
+description: "To successfully send webhook notifications from Bullhorn, follow these steps in your Bullhorn account and complete the required actions."
 ---
 
 import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 
-## Send the assessment/background check invitation to the candidate
+## Send the assessment or background check invitation to the candidate
 
 <Steps>
-  <Step title="Select Candidate from the Candidate List">
-    Navigate to the <i>Candidate List's</i> page and select the candidate.
+  <Step title="Select a Candidate from the Candidate List">
+    Navigate to the <i>Candidate List</i> page and select a candidate.
     <Frame>
       <img className='rounded-md' style={{ margin: '0 auto', border: '1px solid #efefef' }} alt="Maintain Assessment Status" src="/images/bullhorn-assessment-background-check/bullhorn-aab-1.png" />
     </Frame>
 
-    Click on the candidate to open their application. Then, click on the tab `Background check`.
+    Click on the candidate to open their application, then click on the `Assessment or Background Check` tab.
     <Frame>
       <img className='rounded-md' style={{ margin: '0 auto', border: '1px solid #efefef' }} alt="Maintain Assessment Status" src="/images/bullhorn-assessment-background-check/bullhorn-aab-2.png" />
     </Frame>
   </Step>
 
-  <Step title="To Select Background check & Send the Notification">
-    Click on the `Background check` button.
+  <Step title="Select test & send the notification">
+    Click the `Send Assessment or Background Check` button.
     <Frame>
       <img className='rounded-md' style={{ margin: '0 auto', border: '1px solid #efefef' }} alt="Edit/View Assessment/Background check Status ID" src="/images/bullhorn-assessment-background-check/bullhorn-aab-3.png" />
     </Frame>
 
-    A row will appear to select the background check test.
+    A row will appear to select the assessment or background check.
     <Frame>
       <img className='rounded-md' style={{ margin: '0 auto', border: '1px solid #efefef' }} alt="Edit/View Assessment/Background check Status ID" src="/images/bullhorn-assessment-background-check/bullhorn-aab-4.png" />
     </Frame>
 
-    Select the `Background check` test and click on `Send` button to dispatch the notification.
+    Select the test and click the `Send` button to dispatch the notification.
     <Frame>
       <img className='rounded-md' style={{ margin: '0 auto', border: '1px solid #efefef' }} alt="Edit/View Assessment/Background check Status ID" src="/images/bullhorn-assessment-background-check/bullhorn-aab-5.png" />
     </Frame>
 
-    Once the background check notification is successfully sent, a record will be appended with a `Pending` status.
+    Once the assessment or background check notification is sent successfully, a record will be updated with a `Pending` status.
     <Frame>
       <img className='rounded-md' style={{ margin: '0 auto', border: '1px solid #efefef' }} alt="Edit/View Assessment/Background check Status ID" src="/images/bullhorn-assessment-background-check/bullhorn-aab-6.png" />
     </Frame>
   </Step>
 </Steps>
 
-## To check updated result of the assessment/background check invitation of the candidate
+
+## Check the updated result of the candidate's assessment or background check invitation
 
 <Steps>
-  <Step title="To see the updated results of assessment/background check">
-    Click on the candidate's name to view their application. You will see the updated results along with the score from the previously sent test, Whenever the candidate has completed the assessment and background check.
+  <Step title="See the updated results of the assessment or background check">
+    Click on the candidate's name to view their application. When the candidate has completed the assessment or background check, you will see the updated results along with the score from the test.
     <Frame>
       <img className='rounded-md' style={{ margin: '0 auto', border: '1px solid #efefef' }} alt="View Assessment/Background check Updated Results" src="/images/bullhorn-assessment-background-check/bullhorn-aab-7.png" />
     </Frame>
@@ -57,6 +58,7 @@ import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 
 <IntegrationFooter />
+
 
 ## Useful Links
 <Card title="API Reference" icon="link" href="https://bullhorn.github.io/rest-api-docs/">


### PR DESCRIPTION
## Context

<img width="1851" height="2654" alt="screencapture-localhost-3000-integration-configuration-concepts-ats-bullhorn-assessment-background-check-2025-08-28-12_01_11" src="https://github.com/user-attachments/assets/7390ed77-ba8d-4a7a-9d7e-11771f15d63f" />

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Clarifies Bullhorn Assessment/Background Check docs to match Bullhorn UI and webhook flow. Addresses INT-6508 by making the T2 guide clearer and easier to follow.

- **Refactors**
  - Updated wording from “test notifications” to “webhook notifications.”
  - Unified terminology: “Assessment or Background Check” tab/button and steps.
  - Streamlined steps for sending invitations and checking results (including Pending status and score).
  - Grammar and clarity fixes for concise, consistent instructions.

<!-- End of auto-generated description by cubic. -->

