### PR TITLE
[INT-6554] ATS Workday Assessment T2 Doc Improvements

### DIFF
--- a/integration-configuration-concepts/ats/workday-assessment.mdx
+++ b/integration-configuration-concepts/ats/workday-assessment.mdx
@@ -1,236 +1,143 @@
 ---
-title: "Workday Assessment"
-description: "To successfully receive webhook notifications from Workday, follow these steps to configure the Assessment-related settings in your Workday account, and complete the necessary actions."
+title: "Workday Assessments"
+description: "To successfully manage candidate assessments in Workday and ensure seamless integration, follow this guide to configure your Workday account and perform the necessary actions."
 ---
 
 import IntegrationFooter from "/snippets/integration-footer.mdx";
 
-<Warning>
-  This guidance assumes that you have admin privileges for your Workday account.
-</Warning>
 
-## Create Assessment Category in Workday
+## Applying for a Job on Behalf of a Candidate
 
 <Steps>
-  <Step title="Create an assessment category">
-    Navigate to the <i>Maintain Recruiting Assessment Categories</i> page and add a new assessment category called `Technical Assessment Test`.
-    <Frame>
-      <img className='rounded-md' style={{ margin: '0 auto', border: '1px solid #efefef' }} alt="Maintain Assessment Categories" src="/images/workday-assessment/Assessment_category_1.png" />
-    </Frame>
-
-    Please click on the `OK` button to save and the `Done` button to confirm.
-    <Frame>
-      <img className='rounded-md' style={{ margin: '0 auto', border: '1px solid #efefef' }} alt="Assessment Category" src="/images/workday-assessment/Assessment_category_2.png" />
-    </Frame>
-  </Step>
-</Steps>
-
-
-## Create Assessment Test in Workday
-
-<Steps>
-  <Step title="Create an Assessment Test">
-    Navigate to the <i>Maintain Recruiting Assessment Tests</i> page and add an assessment test called `Technical Assessment`.
-    <Frame>
-      <img className='rounded-md' style={{ margin: '0 auto', border: '1px solid #efefef' }} alt="Maintain Assessment Tests" src="/images/workday-assessment/Assessment_test_1.png" />
-    </Frame>
-
-    Enter the test name, select the assessment category created in the previous step, and choose the integration system generated from StackOne, named `StackOne_IS_System`.
-    <Frame>
-      <img className='rounded-md' style={{ margin: '0 auto', border: '1px solid #efefef' }} alt="Assessment Tests" src="/images/workday-assessment/Assessment_test_2.png" />
-    </Frame>
-
-    Please click on the `OK` button to save and the `Done` button to confirm.
-  </Step>
-
-  <Step title="To edit or retrieve the Assessment Test ID">
-    Click on the three-dot menu, go to `View IDs` to see and click on `Edit Reference ID` to make changes to the Reference ID.
-    <Frame>
-      <img className='rounded-md' style={{ margin: '0 auto', border: '1px solid #efefef' }} alt="Edit/View Assessment Test ID" src="/images/workday-assessment/Assessment_test_3.png" />
-    </Frame>
-  </Step>
-
-  <Step title="Use of Assessment Test ID">
-    You'll need the `Assessment_Test_ID` which is `RECRUITING_ASSESSMENT_TEST-6-111` here for notification payload configurations.
-    <Frame>
-      <img className='rounded-md' style={{ margin: '0 auto', border: '1px solid #efefef' }} alt="Assessment Test ID" src="/images/workday-assessment/Assessment_test_4.png" />
-    </Frame>
-  </Step>
-</Steps>
-
-
-## Create Assessment Status in Workday
-
-<Steps>
-  <Step title="Create an Assessment Status">
-    Navigate to the <i>Maintain Assessment Statuses</i> page and add a new assessment status (you can name it as `Invited` same as status name, or any name of your choice).
-    <Frame>
-      <img className='rounded-md' style={{ margin: '0 auto', border: '1px solid #efefef' }} alt="Maintain Assessment Status" src="/images/workday-assessment/Assessment_status_1.png" />
-    </Frame>
-
-    Enter the status name, check the overall status and test status. Click on `OK` and `Done` buttons to save and confirm, respectively.
-  </Step>
-
-  <Step title="To edit or retrieve the Assessment Status ID">
-    Click on the three-dot menu, go to `View IDs` to see and click on `Edit Reference ID` to modify the Reference ID.
-    <Frame>
-      <img className='rounded-md' style={{ margin: '0 auto', border: '1px solid #efefef' }} alt="Edit/View Assessment Status ID" src="/images/workday-assessment/Assessment_test_3.png" />
-    </Frame>
-  </Step>
-
-  <Step title="Use of Assessment Status ID">
-    The Assessment Status ID is used to send the assessment invite notification, so please ensure it is set to `Invited` regardless of the status name provided.
-    <Frame>
-      <img className='rounded-md' style={{ margin: '0 auto', border: '1px solid #efefef' }} alt="Assessment Status ID" src="/images/workday-assessment/Assessment_status_3.png" />
-    </Frame>
-  </Step>
-</Steps>
-
-
-## Job requisitions within the supervisory organization in Workday
-
-<Warning>
-  These steps assume you already have a Supervisory Organization in your Workday account. If not, please contact your admin to create one.
-</Warning>
-
-<Steps>
-  <Step title="Listed Job Requisitions">
-    Navigate to your<i>Supervisory Organization</i> page. Go to the `Staffing` tab below.
-    <Frame>
-      <img className='rounded-md' style={{ margin: '0 auto', border: '1px solid #efefef' }} alt="SO for JR" src="/images/workday-assessment/SO_for_JR.png" />
-    </Frame>
-
-    You can find the list of Job Requisitions that the Assessment stage supports for sending notifications within the Integration System under `Positions with Open Job Requisition` grid.
-  </Step>
-
-  <Step title="No Listed Job Requisitions">
-    If you haven't listed jobs under `Positions with Open Job Requisition`, find `Create Position` under Staffing in the 3-dot menu.
-    <Frame>
-      <img className='rounded-md' style={{ margin: '0 auto', border: '1px solid #efefef' }} alt="Create Job Position" src="/images/workday-assessment/SO_1.png" />
-    </Frame>
-
-    Fill in the required details to create a position that will be visible in the `Positions without Job Requisition` grid.
-    <Frame>
-      <img className='rounded-md' style={{ margin: '0 auto', border: '1px solid #efefef' }} alt="Created Job Position" src="/images/workday-assessment/SO_2.png" />
-    </Frame>
-
-    Navigate to the `Create Job Requisition` and select your supervisory organization and position. After clicking the `OK` button, please fill out the Job Requisition form and `Submit` it.
-    <Frame>
-      <img className='rounded-md' style={{ margin: '0 auto', border: '1px solid #efefef' }} alt="Add in Position in Job Req" src="/images/workday-assessment/SO_3.png" />
-    </Frame>
-
-    The position will now be visible in the `In Progress Requisition Actions` grid.
-    <Frame>
-      <img className='rounded-md' style={{ margin: '0 auto', border: '1px solid #efefef' }} alt="Added in Position in Job Req" src="/images/workday-assessment/SO_4.png" />
-    </Frame>
-
-    Once the job requisition is approved, it will be visible in the `Positions with Open Job Requisition` grid and will be able to support sending notifications.
-    <Frame>
-      <img className='rounded-md' style={{ margin: '0 auto', border: '1px solid #efefef' }} alt="Approved Job Req" src="/images/workday-assessment/SO_5.png" />
-    </Frame>
-  </Step>
-</Steps>
-
-
-## Update Assess Candidate Business Process in Workday
-
-<Steps>
-  <Step title="Select to update the Integration System">
-    Navigate to the <i>Assess Candidate Business Process</i> page. Then, click on the `Configure StackOne_IS_System` button.
-    <Frame>
-      <img className='rounded-md' style={{ margin: '0 auto', border: '1px solid #efefef' }} alt="BP Config IS" src="/images/workday-assessment/BP_Config_IS.png" />
-    </Frame>
-
-    Please select `StackOne_IS_System` as the integration and then click on the `OK` button.
-    <Frame>
-      <img className='rounded-md' style={{ margin: '0 auto', border: '1px solid #efefef' }} alt="Select IS on Popup" src="/images/workday-assessment/Select_IS_on_Popup.png" />
-    </Frame>
-  </Step>
-
-  <Step title="Edit payload attribute values">
-    The pop-up will appear, allowing you to select the values for the fields included in the payload request when the `Invited` event is triggered from Workday.
-    <Frame>
-      <img className='rounded-md' style={{ margin: '0 auto', border: '1px solid #efefef' }} alt="Set Values for Fields" src="/images/workday-assessment/Set_Values_for_Fields.png" />
-    </Frame>
-    
-    **Please fill in the following information:**
-
-    - **Candidate First Name:** [First Name]
-    - **Candidate Last Name:** [Last Name]
-    - **Candidate Email Address:** [Email]
-    - **Candidate Reference ID:** [Candidate ID]
-    - **Job Application Reference ID:** [Job Requisition as Text]
-    - **Assessment Test Reference ID:** [Assessment_Test_ID for the assessment you want to send to the candidate]
-
-    Click the `OK` button to save your configurations.
-  </Step>
-</Steps>
-
-
-## Submit your application for the job from the candidate's profile in Workday
-
-<Steps>
-  <Step title="Apply to the Job">
-    Go to the <i>Find Candidates</i> page, select a Candidate's Profile, and click on `Job Application` under `Actions` to apply for the job.
+  <Step title="Apply for a Job">
+    Navigate to the <i>Find Candidates</i> page, select a candidate's profile, and under `Actions`, click on `Job Application` to apply for a job on their behalf.
     <Frame>
       <img className='rounded-md' style={{ margin: '0 auto', border: '1px solid #efefef' }} alt="Candidate Profile" src="/images/workday-assessment/Candidate_profile_1.png" />
     </Frame>
   </Step>
 
-  <Step title="Select the listed Job Requisition">
-    Please select the job from the dropdown menu listed above.
+  <Step title="Select the Job Requisition">
+    From the dropdown menu, select the relevant job.
+    
+    <Accordion title="Finding Job Requisitions within your Supervisory Organisation">
+      <Warning>
+        These steps assume you have a Supervisory Organisation in your Workday account. 
+        If not, please contact your administrator to create one. You will also need the necessary permissions to access the _Supervisory Organisation_ in Workday.
+      </Warning>
+
+      <Step title="Available Job Requisitions">
+        Navigate to your <i>Supervisory Organisation</i> page and go to the `Staffing` tab.
+        <Frame>
+          <img className='rounded-md' style={{ margin: '0 auto', border: '1px solid #efefef' }} alt="SO for JR" src="/images/workday-assessment/SO_for_JR.png" />
+        </Frame>
+
+        Under the `Positions with Open Job Requisition` section, you will find a list of job requisitions that are configured to send notifications for the assessment stage.
+      </Step>
+
+      <Step title="Creating a New Job Requisition">
+        If no jobs are listed under `Positions with Open Job Requisition`, find `Create Position` under the `Staffing` tab in the three-dot menu.
+        <Frame>
+          <img className='rounded-md' style={{ margin: '0 auto', border: '1px solid #efefef' }} alt="Create Job Position" src="/images/workday-assessment/SO_1.png" />
+        </Frame>
+
+        Fill in the required details to create a position. It will then appear in the `Positions without Job Requisition` section.
+        <Frame>
+          <img className='rounded-md' style={{ margin: '0 auto', border: '1px solid #efefef' }} alt="Created Job Position" src="/images/workday-assessment/SO_2.png" />
+        </Frame>
+
+        Navigate to `Create Job Requisition`, select your supervisory organisation and position, click `OK`, complete the Job Requisition form, and then `Submit` it.
+        <Frame>
+          <img className='rounded-md' style={{ margin: '0 auto', border: '1px solid #efefef' }} alt="Add in Position in Job Req" src="/images/workday-assessment/SO_3.png" />
+        </Frame>
+
+        The position will now appear in the `In Progress Requisition Actions` section.
+        <Frame>
+          <img className='rounded-md' style={{ margin: '0 auto', border: '1px solid #efefef' }} alt="Added in Position in Job Req" src="/images/workday-assessment/SO_4.png" />
+        </Frame>
+
+        Once the job requisition is approved, it will appear in the `Positions with Open Job Requisition` section and will be enabled for notifications.
+        <Frame>
+          <img className='rounded-md' style={{ margin: '0 auto', border: '1px solid #efefef' }} alt="Approved Job Req" src="/images/workday-assessment/SO_5.png" />
+        </Frame>
+      </Step>
+    </Accordion>
+
     <Frame>
       <img className='rounded-md' style={{ margin: '0 auto', border: '1px solid #efefef' }} alt="Candidate Job Apply" src="/images/workday-assessment/Candidate_profile_2.png" />
     </Frame>
 
-    Enter the required details and click the `OK` button to submit the job application.
+    Enter the required details and click `OK` to submit the job application.
   </Step>
 </Steps>
 
 
-## Move Candidate to the Assessment Stage in Workday
+## Moving a Candidate to the Assessment Stage
 
 <Steps>
   <Step title="Go to the Job Requisition">
-    Navigate to the <i>Job Requisitions</i> page by selecting the same Job Requisition from the pop-up where the candidate applied for the job.
+    Navigate to the <i>Job Requisitions</i> page and select the job requisition for which the candidate has applied.
     <Frame>
       <img className='rounded-md' style={{ margin: '0 auto', border: '1px solid #efefef' }} alt="View JR" src="/images/workday-assessment/JR_1.png" />
     </Frame>
 
-    Navigate to the `Candidate` tab and select the `Review` tab, where the candidate will be displayed in the grid below.
+    Go to the `Candidates` tab and select the `Review` sub-tab, where the candidate will be displayed.
     <Frame>
       <img className='rounded-md' style={{ margin: '0 auto', border: '1px solid #efefef' }} alt="Candidate Job Apply" src="/images/workday-assessment/JR_5.png" />
     </Frame>
   </Step>
 
-  <Step title="Move Candidate from Review to Assessment stage">
-    Check the candidate in the grid and click the `Move Forward` button.
+  <Step title="Move Candidate to the Assessment Stage">
+    Select the candidate in the grid and click `Move Forward`.
     <Frame>
       <img className='rounded-md' style={{ margin: '0 auto', border: '1px solid #efefef' }} alt="View JR" src="/images/workday-assessment/JR_2.png" />
     </Frame>
   </Step>
 
-  <Step title="Select Assessment from the dropdown">
-    In the pop-up, select the next stage, which is likely the Assessment Stage. Choose `Assessment` in both dropdown menus.
+  <Step title="Select 'Assessment' from the Dropdown Menu">
+    In the pop-up window, select `Assessment` as the next stage from both dropdown menus.
     <Frame>
       <img className='rounded-md' style={{ margin: '0 auto', border: '1px solid #efefef' }} alt="Candidate Job Apply" src="/images/workday-assessment/JR_3.png" />
     </Frame>
 
-    Click on the `OK` button to move.
+    Click `OK` to confirm.
   </Step>
 
-  <Step title="Candidate Moved to the Assessment Stage">
-    If you go to the `Assessment` tab, the candidate will now be in the Assessment stage.
+  <Step title="Confirm the Candidate is in the Assessment Stage">
+    Navigate to the `Assessment` tab to see the candidate in the assessment stage.
     <Frame>
       <img className='rounded-md' style={{ margin: '0 auto', border: '1px solid #efefef' }} alt="View JR" src="/images/workday-assessment/JR_4.png" />
     </Frame>
-
-    If you're unable to move the candidate to the assessment stage directly, then shift the stages one at a time.
+    
+    <Info>
+      If you are unable to move the candidate directly to the assessment stage, you may need to advance them through each stage one by one.
+    </Info>
   </Step>
 </Steps>
 
 
-## Send the assessment invitation to the candidate using Start Proxy
+## Sending the Assessment Invitation (as a Recruiter)
+
+If you are the recruiter, you can send the assessment invitation directly.
+
+<Steps>
+  <Step title="Send the Assessment Invitation">
+    You should see an `Assess` button next to the candidate's name. Click it to open the assessment form.
+    <Frame>
+      <img className='rounded-md' style={{ margin: '0 auto', border: '1px solid #efefef' }} alt="Sending Invite" src="/images/workday-assessment/Recruiter_1.png" />
+    </Frame>
+  </Step>
+
+  <Step title="Complete the Assessment Form">
+    Set the **Overall Status** to `Invited` and select the appropriate assessment (e.g., `Technical Assessment`) from the dropdown menu.
+    <Frame>
+      <img className='rounded-md' style={{ margin: '0 auto', border: '1px solid #efefef' }} alt="Send Invite" src="/images/workday-assessment/Recruiter_2.png" />
+    </Frame>
+    Click `Submit` to send the invitation and trigger the webhook notification from Workday. 
+  </Step>
+</Steps>
+
+
+## Sending the Assessment Invitation (via Start Proxy)
 
 <Steps>
   <Step title="Sending via Start Proxy">
@@ -240,27 +147,27 @@ import IntegrationFooter from "/snippets/integration-footer.mdx";
     </Frame>
   </Step>
 
-  <Step title="Navigate to the Start Proxy">
-    Go to the <i>Start Proxy</i> page and select Recruiter from the dropdown menu.
+  <Step title="Use Start Proxy">
+    Navigate to the <i>Start Proxy</i> page and select the recruiter from the dropdown menu.
     <Frame>
       <img className='rounded-md' style={{ margin: '0 auto', border: '1px solid #efefef' }} alt="Start Proxy" src="/images/workday-assessment/NR_2.png" />
     </Frame>
 
-    You'll be taken to the recruiter's homepage, where you need to navigate to the `My Tasks` page in the top-right corner.
+    You will be redirected to the recruiter's homepage. Navigate to the `My Tasks` page in the top-right corner.
     <Frame>
       <img className='rounded-md' style={{ margin: '0 auto', border: '1px solid #efefef' }} alt="My Tasks" src="/images/workday-assessment/NR_3.png" />
     </Frame>
 
-    You will find the task at the top labeled with Job Requisition and Candidate name in the sidebar.
+    You will find the assessment task at the top of the sidebar, labelled with the job requisition and candidate name.
     <Frame>
       <img className='rounded-md' style={{ margin: '0 auto', border: '1px solid #efefef' }} alt="Sidebar" src="/images/workday-assessment/NR_4.png" />
     </Frame>
 
-    Clicking on the sidebar task will display the candidate's assessment details on the right side.
+    Clicking on the task will display the candidate's assessment details on the right.
   </Step>
 
   <Step title="Send the Assessment Invitation">
-    You should set the Overall Status to `Invited` and select the Assessment as `Technical Assessment` from the dropdown menu. After that, click the `Submit` button.
+    Set the **Overall Status** to `Invited` and select the appropriate assessment (e.g., `Technical Assessment`) from the dropdown menu. After that, click `Submit`.
     <Frame>
       <img className='rounded-md' style={{ margin: '0 auto', border: '1px solid #efefef' }} alt="Assessment Form" src="/images/workday-assessment/NR_5.png" />
     </Frame>
@@ -268,7 +175,7 @@ import IntegrationFooter from "/snippets/integration-footer.mdx";
 </Steps>
 
 
-## Send the assessment invitation to the candidate without using a Start Proxy
+## Sending the Assessment Invitation (without Start Proxy)
 
 <Steps>
   <Step title="Sending without Start Proxy">
@@ -290,26 +197,18 @@ import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 ## To verify the sent assessment invitation for the candidate
 
-<Steps>
-  <Step title="Verify the sent assessment inivitation">
-    To access the _Job Application_, click on the candidate's profile. Go to the _Screening_ > Assessments tab
-    <Frame>
-      <img className='rounded-md' style={{ margin: '0 auto', border: '1px solid #efefef' }} alt="Sent Invite" src="/images/workday-assessment/sent_assess_request.png" />
-    </Frame>
-  </Step>
-</Steps>
+To access the _Job Application_, click on the candidate's profile. Go to the _Screening_ > Assessments tab
+<Frame>
+  <img className='rounded-md' style={{ margin: '0 auto', border: '1px solid #efefef' }} alt="Sent Invite" src="/images/workday-assessment/sent_assess_request.png" />
+</Frame>
 
 
 ## To check the updated result of the candidate's assessment
 
-<Steps>
-  <Step title="Check assessment result">
-    To access the _Job Application_, click on the candidate's profile. Go to the _Screening_ > Assessments tab
-    <Frame>
-      <img className='rounded-md' style={{ margin: '0 auto', border: '1px solid #efefef' }} alt="Sent Invite" src="/images/workday-assessment/result_update_assess.png" />
-    </Frame>
-  </Step>
-</Steps>
+To check the results of a completed assessment, go to the candidate's profile and navigate to the _Job Application_ > _Screening_ > _Assessments_ tab.
+<Frame>
+  <img className='rounded-md' style={{ margin: '0 auto', border: '1px solid #efefef' }} alt="Sent Invite" src="/images/workday-assessment/result_update_assess.png" />
+</Frame>
 
 
 <IntegrationFooter />

--- a/integration-configuration-concepts/ats/workday-assessment.mdx
+++ b/integration-configuration-concepts/ats/workday-assessment.mdx
@@ -27,6 +27,9 @@ import IntegrationFooter from "/snippets/integration-footer.mdx";
 
       <Step title="Available Job Requisitions">
         Navigate to your <i>Supervisory Organisation</i> page and go to the `Staffing` tab.
+        <Info>
+          Ensure the Supervisory Organization's Staffing Model is `Position Management`
+        </Info>
         <Frame>
           <img className='rounded-md' style={{ margin: '0 auto', border: '1px solid #efefef' }} alt="SO for JR" src="/images/workday-assessment/SO_for_JR.png" />
         </Frame>


### PR DESCRIPTION
## Context

<img width="1847" height="17490" alt="screencapture-localhost-3000-integration-configuration-concepts-ats-workday-assessment-2025-08-29-12_27_38" src="https://github.com/user-attachments/assets/bc799b58-8a1c-4587-9bb8-c2c803a9d5fc" />

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Streamlined the Workday Assessments (T2) doc to focus on the recruiter workflow: apply on behalf, move to Assessment, and send invites, with clear Start Proxy and non‑proxy options. Addresses INT-6554 by removing obsolete setup steps and making the guide easier to follow.

- **Refactors**
  - Retitled page and rewrote content around an end-to-end recruiter flow.
  - Removed admin-only setup (assessment categories/tests/statuses and Assess Candidate BP payload config).
  - Added concise steps to find/create job requisitions within Supervisory Organisations; updated screenshots and warnings.
  - Clarified invite sending (recruiter, Start Proxy, or without), verification, and results; note that setting Overall Status to Invited triggers the webhook.

<!-- End of auto-generated description by cubic. -->

