### PR TITLE
chore:added additional ocn configuration setting to docs

### DIFF
--- a/connection-guides/lms/sapsuccessfactors.mdx
+++ b/connection-guides/lms/sapsuccessfactors.mdx
@@ -307,6 +307,7 @@ To configure the OCN property file, take the following steps:
     defaultValues.autoImportOCNCourseEnabled[default]=value
 
     - This should be set to true either for all providers or for a specific provider, to automate the import of content. If set to true, the content will be automatically imported into SuccessFactors when it is published in the provider.
+
     <Note>
       If you want any of the above configurations to be specific to a provider, you can add `provider_name` instead of `default` in the property name - e.g. defaultValues.itemType[provider_name]=value
     </Note>
@@ -339,6 +340,10 @@ To automate the OCN content sync process, take the following steps:
 </Steps>
 
 ### Importing Content
+
+<Note>
+  If you have enabled the autoImportOCNCourseEnabled property in the OCN property file, you can skip the manual import step below.
+</Note>
 
 Once OCN content is being automatically made availble for import as per the steps above you may manually import the content into the system
 


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Added the OCN setting defaultValues.autoImportOCNCourseEnabled to the SAP SuccessFactors LMS guide to enable automatic import of provider content when published. Notes that it can be set globally or per provider and when to set it to true.

<!-- End of auto-generated description by cubic. -->

