### PR TITLE
[INT-6476] ATS SAP SF T2 Doc instructions update

### DIFF
--- a/integration-configuration-concepts/ats/sapsuccessfactors-assessment.mdx
+++ b/integration-configuration-concepts/ats/sapsuccessfactors-assessment.mdx
@@ -23,6 +23,10 @@ import IntegrationFooter from "/snippets/integration-footer.mdx";
     - **Status:** Select the stage at which the vendor established the assessment integration feature.
     - **Vendor:** Select the vendor.
     - **Assessment:** Select the assessment package that the recruiter wants to send to the candidate.
+    <Warning>
+      If the assessment vendor packages are not listed in the dropdown menu, please reach out to the vendor to arrange for the assessment packages. <br />
+      The vendor will provide you with a CSV file of the assessment vendor packages, which you can upload from the _Provisioning Account_ by navigating to _Managing Recruiting_ and selecting _Import/Export Assessment Vendor Packages_.
+    </Warning>
     - **Email Template:** Select the email template that will be sent to the candidate once the assessment is triggered.
   </Step>
 </Steps>


### PR DESCRIPTION
Instruction update for Provisioning Account
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds a warning to the SAP SuccessFactors Assessment (T2) setup docs explaining what to do when vendor packages are missing from the dropdown. Instructs admins to request a CSV from the vendor and upload it in Provisioning (Managing Recruiting > Import/Export Assessment Vendor Packages), aligning with INT-6476.

<!-- End of auto-generated description by cubic. -->

