### PR TITLE
HRIS - Workday - additional permissions required for List Time Off Policies

### DIFF
--- a/connection-guides/hris/workday.mdx
+++ b/connection-guides/hris/workday.mdx
@@ -175,7 +175,6 @@ import IntegrationFooter from "/snippets/integration-footer.mdx";
         - Time Off Manager View
         - Time Off Balances
         - Time Off Balances Manager View
-      - Set Up: Time Off (Calculations - Absence Specific)
       - **Leave of Absence**
       - Workers
     - Set Up: Time Off

--- a/connection-guides/hris/workday_OAuth2.mdx
+++ b/connection-guides/hris/workday_OAuth2.mdx
@@ -195,9 +195,11 @@ import IntegrationFooter from "/snippets/integration-footer.mdx";
         - Time Off Manager View
         - Time Off Balances
         - Time Off Balances Manager View
-      - Set Up: Time Off (Calculations - Absence Specific)
       - **Leave of Absence**
       - Workers
+    - Set Up: Time Off
+    - Set Up: Time Off (Calculations - Absence Specific)
+    - System Auditing
     - View: National Identifiers - All
   </Step>
 </Steps>


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Updated the Workday HRIS connection guides to use the Unconstrained integration security group and add missing Time Off permissions. This prevents permission errors when listing Time Off Policies.

- **Bug Fixes**
  - Set security group type to "Integration System Security Group (Unconstrained)" in both guides.
  - Added required permissions: Set Up: Time Off, Set Up: Time Off (Calculations - Absence Specific), and System Auditing.

<!-- End of auto-generated description by cubic. -->

