### PR TITLE
docs: add parent portal ID configuration section to Go1 integration guide

### DIFF
--- a/connection-guides/lms/go1.mdx
+++ b/connection-guides/lms/go1.mdx
@@ -90,6 +90,18 @@ description: "If you've been directed to StackOne to integrate with GO1, the fol
 
   This is a centralised way to manage which content will be made available to your users in the third party LMS/LXP.
 
-  [GO1 Admin](https://developers.go1.com/products/go1-admin/)
+  <Steps>
+    <Step title="Configure Parent Portal ID">
+      To enable this integration to work you will need to work with your Go1 support to configure the parent portal ID to the ID of your integration partner.
+
+      This will ensure you are able to curate your library as an opt-in for content rather than an opt-out.
+    </Step>
+
+    <Step title="Access GO1 Admin">
+      Once the parent portal ID is configured, you can manage content visibility through GO1 Admin.
+
+      [GO1 Admin](https://developers.go1.com/products/go1-admin/)
+    </Step>
+  </Steps>
 
 


### PR DESCRIPTION
Enhanced the Content Visibility section with structured steps for configuring the parent portal ID with Go1 support to enable opt-in content curation.

Resolves #299

Generated with [Claude Code](https://claude.ai/code)
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added clear steps to configure the Go1 parent portal ID in the Content Visibility section, enabling opt-in content curation. Includes a pointer to GO1 Admin for managing visibility after setup.

<!-- End of auto-generated description by cubic. -->

