### PR TITLE
[INT-6554] ATS Workday Assessment T2 doc change requests fixes

### DIFF
--- a/integration-configuration-concepts/ats/workday-assessment.mdx
+++ b/integration-configuration-concepts/ats/workday-assessment.mdx
@@ -118,28 +118,6 @@ import IntegrationFooter from "/snippets/integration-footer.mdx";
 </Steps>
 
 
-## Sending the Assessment Invitation (as a Recruiter)
-
-If you are the recruiter, you can send the assessment invitation directly.
-
-<Steps>
-  <Step title="Send the Assessment Invitation">
-    You should see an `Assess` button next to the candidate's name. Click it to open the assessment form.
-    <Frame>
-      <img className='rounded-md' style={{ margin: '0 auto', border: '1px solid #efefef' }} alt="Sending Invite" src="/images/workday-assessment/Recruiter_1.png" />
-    </Frame>
-  </Step>
-
-  <Step title="Complete the Assessment Form">
-    Set the **Overall Status** to `Invited` and select the appropriate assessment (e.g., `Technical Assessment`) from the dropdown menu.
-    <Frame>
-      <img className='rounded-md' style={{ margin: '0 auto', border: '1px solid #efefef' }} alt="Send Invite" src="/images/workday-assessment/Recruiter_2.png" />
-    </Frame>
-    Click `Submit` to send the invitation and trigger the webhook notification from Workday. 
-  </Step>
-</Steps>
-
-
 ## Sending the Assessment Invitation (via Start Proxy)
 
 <Steps>
@@ -178,22 +156,24 @@ If you are the recruiter, you can send the assessment invitation directly.
 </Steps>
 
 
-## Sending the Assessment Invitation (without Start Proxy)
+## Sending the Assessment Invitation (as a Recruiter)
+
+If you are the recruiter, you can send the assessment invitation directly.
 
 <Steps>
-  <Step title="Sending without Start Proxy">
-    If you are the recruiter, you should see the `Assess` button next to the candidate's name.
+  <Step title="Send the Assessment Invitation">
+    You should see an `Assess` button next to the candidate's name. Click it to open the assessment form.
     <Frame>
       <img className='rounded-md' style={{ margin: '0 auto', border: '1px solid #efefef' }} alt="Sending Invite" src="/images/workday-assessment/Recruiter_1.png" />
     </Frame>
   </Step>
 
-  <Step title="Send the Assessment Invitation">
-    You should set the Overall Status to `Invited` and select the Assessment as `Technical Assessment` from the dropdown menu.
+  <Step title="Complete the Assessment Form">
+    Set the **Overall Status** to `Invited` and select the appropriate assessment (e.g., `Technical Assessment`) from the dropdown menu.
     <Frame>
       <img className='rounded-md' style={{ margin: '0 auto', border: '1px solid #efefef' }} alt="Send Invite" src="/images/workday-assessment/Recruiter_2.png" />
     </Frame>
-    Click on the `Submit` button to get the webhook notification from Workday. 
+    Click `Submit` to send the invitation and trigger the webhook notification from Workday. 
   </Step>
 </Steps>
 


### PR DESCRIPTION
ATS Workday Assessment T2 doc change requests fixes
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Consolidated and clarified the Workday Assessment T2 recruiter invite steps to remove duplication and match actual behavior. Aligns the doc with INT-6554 requirements.

- **Refactors**
  - Removed the duplicate recruiter invitation section and merged into a single flow.
  - Renamed “without Start Proxy” to “as a Recruiter” for accuracy.
  - Tightened step copy: use Assess button, set Overall Status to Invited, choose the appropriate assessment (e.g., Technical Assessment), then Submit to trigger the webhook.

<!-- End of auto-generated description by cubic. -->

