### PR TITLE
HRIS - Workday - additional API Client scopes 

### DIFF
--- a/connection-guides/hris/workday_OAuth2.mdx
+++ b/connection-guides/hris/workday_OAuth2.mdx
@@ -233,13 +233,17 @@ import IntegrationFooter from "/snippets/integration-footer.mdx";
     - **Client Name**: e.g. StackOne_Integrations
     - **Non-Expiring Refresh Tokens**: Check the box
     - **Scopes**: Select the required functional scopes to enable data access via API.
-      - _Staffing_
-      - _Time Tracking_
-      - _Time Off and Leave_
-      - _System_
-      - _Workday Designer_
+      - _Advanced Compensation_
+      - _Core Compensation_
       - _Integrations_
+      - _Jobs & Positions_
       - _Organizations and Roles_
+      - _Staffing_
+      - _System_
+      - _Tenant Non-Configurable_
+      - _Time Off and Leave_
+      - _Time Tracking_
+      - _Workday Designer_
 
     <Frame>
       <img


### PR DESCRIPTION
Added additional API Client for Integrations scopes that some Workday customers required for the Get Job Profile request

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the Workday OAuth2 connection guide to include additional API Client scopes required by some tenants for the Get Job Profile request. Adds Advanced Compensation, Core Compensation, Jobs & Positions, and Tenant Non-Configurable, and clarifies the full recommended scope set to avoid missing-scope errors.

<!-- End of auto-generated description by cubic. -->

