### PR TITLE
Update webhook endpoint URL for time-off events

### DIFF
--- a/integration-configuration-concepts/hris/hibob-webhook-configurations.mdx
+++ b/integration-configuration-concepts/hris/hibob-webhook-configurations.mdx
@@ -44,7 +44,7 @@ import IntegrationFooter from "/snippets/integration-footer.mdx";
     Please provide the required details to configure the webhook for `time-off` events:
     - **Name**: Enter the webhook name.
     - **Endpoint URL**: Use the base URL provided by the partner and append your external trigger token from StackOne Hub as follows:
-      `BASE_URL?externalTriggerToken=<Your_External_Trigger_Token>`
+      `https://api.stackone.com/external-trigger/hibob?externalTriggerToken=<Your_External_Trigger_Token>`
     - **Version**: Select the webhook version.
     - **Events**: Choose the time-off event types.
     <Frame>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated the Hibob time-off webhook docs to use the correct StackOne endpoint: https://api.stackone.com/external-trigger/hibob?externalTriggerToken=<Your_External_Trigger_Token>. This prevents misconfiguration and ensures time-off events reach the right endpoint.

<sup>Written for commit 712db170df4ad1121edca53afe02b698ec46e4a1. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

