### PR TITLE
chore:add Reports permission for Hibob service user

### DIFF
--- a/connection-guides/hris/hibob-service-user.mdx
+++ b/connection-guides/hris/hibob-service-user.mdx
@@ -83,6 +83,11 @@ Ensure the following are enabled:
   - See company's time off settings
 </Accordion>
 
+<Accordion title="Reports">
+- Reports
+  - View reports according to people's data access rights
+</Accordion>
+
 
 *In `People's Data` tab*
 <Accordion title="People">


### PR DESCRIPTION
Add 'Features > Reports > View reports according to people's data access rights' permission to support comprehensive data access for integration functionality.

Resolves #311

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the Hibob service user guide to include the Reports permission: Features > Reports > “View reports according to people's data access rights.” This ensures integrations can access reports according to data access rules, avoiding permission errors and incomplete syncs.

<sup>Written for commit a50e6afdf5d3ce2b697fab7e3cfa0b7f3e0e0ddb. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

