### PR TITLE
[INT-7705] ATS Workday RAAS T2 Do updated for ISU Auth steps

### DIFF
--- a/integration-configuration-concepts/ats/workday-raas.mdx
+++ b/integration-configuration-concepts/ats/workday-raas.mdx
@@ -9,6 +9,43 @@ import IntegrationFooter from "/snippets/integration-footer.mdx";
   This guidance assumes that you have admin privileges for your Workday account.
 </Warning>
 
+
+## Set up an Integration System User
+
+<Warning>
+  Setting up an **Integration System User (ISU)** is recommended but optional. You can use an existing Workday user account with appropriate permissions instead. 
+  The key requirement is having valid credentials **(username and password)** with access to create and manage custom reports.
+</Warning>
+
+<Steps>
+  <Step title="Search for Create Integration System User">
+    Search and navigate to the `Create Integration System User` task.
+    <Frame>
+      <img
+        className="rounded-md"
+        style={{ margin:"0 auto",border:"1px solid #efefef" }}
+        alt="Create Integration System User"
+        src="/images/workday-wql/image5.png"
+      />
+    </Frame>
+  </Step>
+
+  <Step title="Enter account information">
+    Enter a username and password in the Account Information section.
+    <Frame>
+      <img
+        className="rounded-md"
+        style={{ margin:"0 auto",border:"1px solid #efefef" }}
+        alt="Account Information"
+        src="/images/workday-wql/image6.png"
+      />
+    </Frame>
+
+    Click `OK` to create the user.
+  </Step>
+</Steps>
+
+
 ## Access Report Designer
 
 <Steps>


### PR DESCRIPTION
ATS Workday RAAS T2 Do updated for ISU Auth steps

<img width="2363" height="9759" alt="screencapture-localhost-3001-integration-configuration-concepts-ats-workday-raas-2025-11-10-18_42_15" src="https://github.com/user-attachments/assets/50b31ccd-dcc1-4962-8dab-d9f97d9eb6a4" />


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the Workday RAAS (T2) documentation to add Integration System User (ISU) authentication steps and clarify credential requirements. This fulfills INT-7705 by providing an optional ISU setup and a simple step-by-step guide with screenshots.

<sup>Written for commit 5661617c421616eaffc8cadd6d9cb30748e0176a. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

