### PR TITLE
[INT-7692] Workday TimeOff permission update

### DIFF
--- a/connection-guides/hris/workday_OAuth2.mdx
+++ b/connection-guides/hris/workday_OAuth2.mdx
@@ -197,10 +197,14 @@ import IntegrationFooter from "/snippets/integration-footer.mdx";
         - Time Off Balances Manager View
       - **Leave of Absence**
       - Workers
+      - Add Worker Documents
     - Set Up: Time Off
     - Set Up: Time Off (Calculations - Absence Specific)
     - System Auditing
     - View: National Identifiers - All
+    - **System:**
+      - Workday Query Language
+      - Business Process Administration
   </Step>
 </Steps>
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated the Workday OAuth2 connection guide to include the missing permissions required to query Time Off comments via WQL, preventing errors when listing employee time off policies. Addresses INT-7692.

- **Bug Fixes**
  - Added Workers: Add Worker Documents.
  - Added System: Workday Query Language and Business Process Administration.

<sup>Written for commit cea6f761a7e1336a12ca024010c0921bde5b479b. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

