### PR TITLE
docs: Add permissions warning to hub documentation

### DIFF
--- a/connection-guides/ats/greenhouse.mdx
+++ b/connection-guides/ats/greenhouse.mdx
@@ -51,6 +51,10 @@ import IntegrationFooter from "/snippets/integration-footer.mdx";
   </Step>
 </Steps>
 
+<Warning>
+  Required permissions may be subject to change.
+</Warning>
+
 ## Generating Job Board API Key
 <Steps> 
   <Step title="Create Job Board API Key">

--- a/connection-guides/documents/notion.mdx
+++ b/connection-guides/documents/notion.mdx
@@ -93,6 +93,10 @@ Log in to your Notion account.
   </Step>
 </Steps>
 
+<Warning>
+  Required permissions may be subject to change.
+</Warning>
+
 ## Find your Version
 
 You can find your Version at https://developers.notion.com/reference/versioning

--- a/connection-guides/documents/onedrive.mdx
+++ b/connection-guides/documents/onedrive.mdx
@@ -9,6 +9,10 @@ import IntegrationFooter from "/snippets/integration-footer.mdx";
   Ensure that your OneDrive account has Admin or Owner privileges.
 </Warning>
 
+<Warning>
+  Required permissions may be subject to change.
+</Warning>
+
 If you've been directed to StackOne to integrate with OneDrive, the following steps will help you understand the process and any necessary actions to configure a successful integration.
 
 ## OAuth \+ File Picker

--- a/connection-guides/documents/sharepoint.mdx
+++ b/connection-guides/documents/sharepoint.mdx
@@ -9,6 +9,10 @@ import IntegrationFooter from "/snippets/integration-footer.mdx";
   Ensure that your Sharepoint account has Admin or Owner privileges.
 </Warning>
 
+<Warning>
+  Required permissions may be subject to change.
+</Warning>
+
 If you've been directed to StackOne to integrate with Sharepoint, the following steps will help you understand the process and any necessary actions to configure a successful integration.
 
 ## OAuth \+ File Picker

--- a/connection-guides/hris/personio-custom-integrations.mdx
+++ b/connection-guides/hris/personio-custom-integrations.mdx
@@ -79,6 +79,10 @@ If you've been directed to StackOne to integrate with Personio, the following st
   </Step>
 </Steps>
 
+<Warning>
+  Required permissions may be subject to change.
+</Warning>
+
 NOTE: Copy your API credentials – client ID and client secret to a safe place.
 
 ## Connecting with StackOne Hub

--- a/connection-guides/hris/personio.mdx
+++ b/connection-guides/hris/personio.mdx
@@ -82,6 +82,10 @@ This guidance assumes you have Admin privileges for your Personio account.
   </Step>
 </Steps>
 
+<Warning>
+  Required permissions may be subject to change.
+</Warning>
+
 ## Connecting with StackOne Hub
 
 <Steps>

--- a/connection-guides/hris/staffologyhr.mdx
+++ b/connection-guides/hris/staffologyhr.mdx
@@ -114,6 +114,10 @@ This guidance assumes you have Admin privileges for your Staffology HR account.
   Creating an API user grants full <strong>Set Rights</strong> permissions.
 </Note>
 
+<Warning>
+  Required permissions may be subject to change.
+</Warning>
+
 ## Connecting with StackOne
 
 <Steps>

--- a/connection-guides/hris/ukgpro.mdx
+++ b/connection-guides/hris/ukgpro.mdx
@@ -173,6 +173,10 @@ This guidance assumes you have Admin privileges for your UKG Pro account.
   </Step>
 </Steps>
 
+<Warning>
+  Required permissions may be subject to change.
+</Warning>
+
 ## Connecting to StackOne
 
 <Steps>

--- a/connection-guides/hris/ukgready-oauth-client-credentials.mdx
+++ b/connection-guides/hris/ukgready-oauth-client-credentials.mdx
@@ -319,6 +319,9 @@ If you've been directed to StackOne to integrate with UKG Ready (OAuth Client Cr
   </Step>
 </Steps>
 
+<Warning>
+  Required permissions may be subject to change.
+</Warning>
 
 ## Job Change Reason Codes
 

--- a/connection-guides/hris/workday.mdx
+++ b/connection-guides/hris/workday.mdx
@@ -185,6 +185,10 @@ import IntegrationFooter from "/snippets/integration-footer.mdx";
   </Step>
 </Steps>
 
+<Warning>
+  Required permissions may be subject to change.
+</Warning>
+
 ## Approve the Security Policy Changes
 
 <Steps>

--- a/connection-guides/iam/googleworkspace-oauth.mdx
+++ b/connection-guides/iam/googleworkspace-oauth.mdx
@@ -183,6 +183,9 @@ Google requires configuring a consent screen to be displayed when granting appli
     </Step>
 </Steps>
 
+<Warning>
+  Required permissions may be subject to change.
+</Warning>
 
 ## Connecting with StackOne
 

--- a/connection-guides/iam/okta.mdx
+++ b/connection-guides/iam/okta.mdx
@@ -9,6 +9,10 @@ import IntegrationFooter from "/snippets/integration-footer.mdx";
   Ensure that your Okta account has **API Access Administrator**, **Organization Administrator**, or  **Super Administrator** privileges.
 </Warning>
 
+<Warning>
+  Required permissions may be subject to change.
+</Warning>
+
 If you've been directed to StackOne to integrate with Okta, the following steps will help you understand the process and any necessary actions to configure a successful integration.
 
 ## Log in to Okta

--- a/connection-guides/iam/teamviewer-oauth.mdx
+++ b/connection-guides/iam/teamviewer-oauth.mdx
@@ -9,6 +9,10 @@ import IntegrationFooter from "/snippets/integration-footer.mdx";
   Ensure that your Teamviewer account has Admin privileges.
 </Warning>
 
+<Warning>
+  Required permissions may be subject to change.
+</Warning>
+
 If you've been directed to StackOne to integrate with Teamviewer, the following steps will help you understand the process and any necessary actions to configure a successful integration.
 
 ## Log in to Teamviewer


### PR DESCRIPTION
Added 'Required permissions may be subject to change' warning callout to 13 hub documentation files that contain detailed permission configuration sections.

This addresses issue #318 by ensuring users are aware that permission requirements may change as providers update their APIs and permission models.

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a standard warning to 13 connection guides stating that required permissions can change as providers update their APIs. Addresses Linear issue #318.

<sup>Written for commit f7e2e67a9ac986f84661fe159c11584d0246ff3e. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

