### PR TITLE
docs: Fix positioning of permissions warnings in hub documentation

### DIFF
--- a/connection-guides/documents/notion.mdx
+++ b/connection-guides/documents/notion.mdx
@@ -69,6 +69,10 @@ Log in to your Notion account.
       <Frame>
           <img className='rounded-md' style={{ margin: '0 auto', border: '1px solid #efefef' }} alt="Check mark required permissions" src="/images/notion/image8.png" />
       </Frame>
+
+      <Warning>
+        Required permissions may be subject to change.
+      </Warning>
   </Step>
   <Step title="Copy the API Secret">
       Click the `Show` button and copy the API Secret to a safe place.

--- a/connection-guides/hris/personio-custom-integrations.mdx
+++ b/connection-guides/hris/personio-custom-integrations.mdx
@@ -79,6 +79,10 @@ If you've been directed to StackOne to integrate with Personio, the following st
   </Step>
 </Steps>
 
+<Warning>
+  Required permissions may be subject to change.
+</Warning>
+
 NOTE: Copy your API credentials – client ID and client secret to a safe place.
 
 ## Connecting with StackOne Hub

--- a/connection-guides/hris/personio.mdx
+++ b/connection-guides/hris/personio.mdx
@@ -65,6 +65,13 @@ This guidance assumes you have Admin privileges for your Personio account.
   <Step title="Create integration">
     After selecting your permissions, click "Create integration" to generate your API credentials.
   </Step>
+</Steps>
+
+<Warning>
+  Required permissions may be subject to change.
+</Warning>
+
+<Steps>
 
   <Step title="Copy API credentials">
     Once the integration is created, you'll see your API credentials displayed:

--- a/connection-guides/hris/staffologyhr.mdx
+++ b/connection-guides/hris/staffologyhr.mdx
@@ -114,6 +114,10 @@ This guidance assumes you have Admin privileges for your Staffology HR account.
   Creating an API user grants full <strong>Set Rights</strong> permissions.
 </Note>
 
+<Warning>
+  Required permissions may be subject to change.
+</Warning>
+
 ## Connecting with StackOne
 
 <Steps>

--- a/connection-guides/hris/ukgpro.mdx
+++ b/connection-guides/hris/ukgpro.mdx
@@ -142,6 +142,10 @@ This guidance assumes you have Admin privileges for your UKG Pro account.
         src="/images/ukgpro/image7.png"
       />
     </Frame>
+
+    <Warning>
+      Required permissions may be subject to change.
+    </Warning>
   </Step>
   <Step title="Save and Generate Password">
     Click Save to generate a new password. Save this password in a secure location.

--- a/connection-guides/hris/ukgready-oauth-client-credentials.mdx
+++ b/connection-guides/hris/ukgready-oauth-client-credentials.mdx
@@ -296,6 +296,10 @@ If you've been directed to StackOne to integrate with UKG Ready (OAuth Client Cr
       </Steps>
     </Accordion>
 
+    <Warning>
+      Required permissions may be subject to change.
+    </Warning>
+
     <Frame>
       <img
         className="rounded-md"

--- a/connection-guides/hris/workday.mdx
+++ b/connection-guides/hris/workday.mdx
@@ -185,6 +185,10 @@ import IntegrationFooter from "/snippets/integration-footer.mdx";
   </Step>
 </Steps>
 
+<Warning>
+  Required permissions may be subject to change.
+</Warning>
+
 ## Approve the Security Policy Changes
 
 <Steps>

--- a/connection-guides/iam/googleworkspace-oauth.mdx
+++ b/connection-guides/iam/googleworkspace-oauth.mdx
@@ -183,6 +183,10 @@ Google requires configuring a consent screen to be displayed when granting appli
     </Step>
 </Steps>
 
+<Warning>
+  Required permissions may be subject to change.
+</Warning>
+
 
 ## Connecting with StackOne
 

--- a/connection-guides/iam/teamviewer-oauth.mdx
+++ b/connection-guides/iam/teamviewer-oauth.mdx
@@ -54,6 +54,10 @@ This connection will authenticate on behalf of a registered Application in Teamv
         - User management: **view users**
         - Group management: **read groups**
 
+        <Warning>
+          Required permissions may be subject to change.
+        </Warning>
+
         Click the **Create** button to proceed.
 
         <Frame>


### PR DESCRIPTION
Fixed the inconsistent positioning of permissions warning callouts to ensure they're always placed after the permissions configuration sections.

Added permissions warning to 8 files with detailed permission configurations, positioning them consistently after permissions configuration sections. This ensures users are aware that permission requirements may change as providers update their APIs.

## Files Updated:
- workday.mdx - After domain security policy permissions
- personio.mdx - After permissions selection section
- ukgready-oauth-client-credentials.mdx - After security profile permissions
- notion.mdx - After content capabilities permissions
- ukgpro.mdx - After web service permissions table
- staffologyhr.mdx - After Set Rights permissions note
- googleworkspace-oauth.mdx - After OAuth scopes configuration
- personio-custom-integrations.mdx - After permission selection steps
- teamviewer-oauth.mdx - Within permission selection step

Resolves #318

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes inconsistent placement of permissions warnings across Hub guides. Warnings now appear immediately after each permissions configuration step to make changes clear and reduce missed context. Resolves #318.

- **Bug Fixes**
  - Inserted a standard “Required permissions may be subject to change.” warning after permissions sections in 9 guides: Workday, Personio (incl. custom integrations), UKG Ready (OAuth Client Credentials), UKG Pro, Notion, Staffology HR, Google Workspace OAuth, and TeamViewer OAuth.

<sup>Written for commit c1fedecec88bb300319009363252b3596f99e0ea. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

