### PR TITLE
[INT-6424] Workday Employee Tasks Required Permissions

### DIFF
--- a/connection-guides/hris/workday_OAuth2.mdx
+++ b/connection-guides/hris/workday_OAuth2.mdx
@@ -185,6 +185,7 @@ import IntegrationFooter from "/snippets/integration-footer.mdx";
       - Work Phone
     - **Worker Data:**
       - All Positions
+      - Public Worker Reports
       - Compensation
       - Current Staffing Information
       - Employment Data


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added "Public Worker Reports" to the required Worker Data permissions in the Workday OAuth2 connection guide. This aligns with INT-6424 by documenting the permission needed to complete approval steps via the Update Task API.

<sup>Written for commit 3427db2d058366b72f4da6df28d975fa68e2b123. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

