### PR TITLE
[INT-7883] - ATS - Bullhorn Recruitment Cloud - Salesforce (OAuth) - Fix Logo

### DIFF
--- a/integrations.mdx
+++ b/integrations.mdx
@@ -13,7 +13,7 @@ import { IntegrationTile } from '/snippets/integration-tile.mdx';
 <IntegrationTile logo={'https://stackone-logos.com/api/ashby/filled/png'} title={'Ashby'} category={'ATS'} link={'/connection-guides/ats/ashby'} />
 <IntegrationTile logo={'https://stackone-logos.com/api/breezy/filled/png'} title={'Breezy HR'} category={'ATS'} link={'/connection-guides/ats/breezyhr'} />
 <IntegrationTile logo={'https://stackone-logos.com/api/bullhorn/filled/png'} title={'Bullhorn'} category={'ATS'} link={'/connection-guides/ats/bullhorn'} />
-<IntegrationTile logo={'https://stackone-logos.com/api/salesforcebullhorn/filled/png'} title={'Bullhorn Recruitment Cloud - Salesforce (OAuth)'} category={'ATS'} link={'/connection-guides/ats/bullhorn_salesforce'} />
+<IntegrationTile logo={'https://stackone-logos.com/api/bullhorn/filled/png'} title={'Bullhorn Recruitment Cloud - Salesforce (OAuth)'} category={'ATS'} link={'/connection-guides/ats/bullhorn_salesforce'} />
 <IntegrationTile logo={'https://stackone-logos.com/api/cornerstone/filled/png'} title={'Cornerstone'} category={'ATS'} link={'/connection-guides/ats/cornerstone'} />
 <IntegrationTile logo={'https://stackone-logos.com/api/eploy/filled/png'} title={'Eploy'} category={'ATS'} link={'/connection-guides/ats/eploy'} />
 <IntegrationTile logo={'https://stackone-logos.com/api/greenhouse/filled/png'} title={'Greenhouse'} category={'ATS'} link={'/connection-guides/ats/greenhouse'} />


### PR DESCRIPTION

<img width="1322" height="747" alt="image" src="https://github.com/user-attachments/assets/75c7e59c-4d39-43e4-bfc5-5d7866e85ce2" />

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes the corrupted logo in the Bullhorn Recruitment Cloud - Salesforce (OAuth) ATS tile by switching the image URL to the standard Bullhorn logo endpoint. Addresses INT-7883 so the hub doc displays the correct logo.

<sup>Written for commit 737def5812e425986f516e6b372da0e771cdabb5. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

