### PR TITLE
chore:removed escalation to integration@ from docs footer

### DIFF
--- a/connection-guides/accounting/xero.mdx
+++ b/connection-guides/accounting/xero.mdx
@@ -3,7 +3,6 @@ title: "Xero"
 description: "Follow these steps to connect Xero via the StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure that your Xero account has the necessary permissions to authorize the integration.
@@ -43,4 +42,3 @@ If you have access to multiple Xero organizations, you can connect additional or
 
 This should be repeated for each additional organization you want to connect.
 
-<IntegrationFooter />

--- a/connection-guides/ats/ashby.mdx
+++ b/connection-guides/ats/ashby.mdx
@@ -3,7 +3,6 @@ title: "Ashby"
 description: "If you have been directed to StackOne to integrate with Ashby, the following steps will help you understand the process and any necessary actions to configure successful integration."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   The following guidance assumes you have Admin privileges for your Ashby
@@ -70,7 +69,6 @@ Upon reaching the Link Account page, enter the generated API key and proceed by 
   />
 </Frame>
 
-<IntegrationFooter />
 
 ## Useful Links
 <Card title="API Reference" icon="link" href="https://developers.ashbyhq.com/reference/introduction">

--- a/connection-guides/ats/breezyhr.mdx
+++ b/connection-guides/ats/breezyhr.mdx
@@ -3,7 +3,6 @@ title: "Breezy HR"
 description: "Follow these steps to connect Breezy HR via the StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure that your Breezy HR account has an **Administrator** Company Role.
@@ -77,7 +76,6 @@ Proceed by clicking the Connect button.
     <img className='rounded-md' style={{ margin: '0 auto', border: '1px solid #efefef' }} alt="Enter Credentials" src="/images/breezyhr/image5.png" />
 </Frame>
 
-<IntegrationFooter />
 
 ## Available data
 

--- a/connection-guides/ats/bullhorn.mdx
+++ b/connection-guides/ats/bullhorn.mdx
@@ -3,7 +3,6 @@ title: "Bullhorn"
 description: "Follow these steps to connect Bullhorn with StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure you have Admin privileges for your Bullhorn account.
@@ -80,7 +79,6 @@ The **Client Contact ID** can be seen by viewing the _Contacts_ of the same Comp
   </Step>
 </Steps>
 
-<IntegrationFooter />
 
 ## Useful Links
 

--- a/connection-guides/ats/bullhorn_salesforce.mdx
+++ b/connection-guides/ats/bullhorn_salesforce.mdx
@@ -3,7 +3,6 @@ title: "Bullhorn Recruitment Cloud - Salesforce (OAuth)"
 description: "Follow these steps to connect Bullhorn Recruitment Cloud - Salesforce via the StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure that your Bullhorn Recruitment Cloud - Salesforce account has Admin privileges.
@@ -141,7 +140,6 @@ To include any additional fields from this model, enter a comma-separated list o
     </Frame>
   </Step>
 </Steps>
-<IntegrationFooter />
 
 ## Available data
 

--- a/connection-guides/ats/cornerstone.mdx
+++ b/connection-guides/ats/cornerstone.mdx
@@ -3,7 +3,6 @@ title: "Cornerstone"
 description: "Follow these steps to connect Cornerstone via the StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure that your Cornerstone account has Admin privileges.
@@ -71,7 +70,6 @@ If you've been directed to StackOne to integrate with Cornerstone, the following
   </Step>
 </Steps>
 
-<IntegrationFooter />
 
 ## Useful Links
 <Card title="API Reference" icon="link" href="https://csod.dev/guides/getting-started/">

--- a/connection-guides/ats/eploy.mdx
+++ b/connection-guides/ats/eploy.mdx
@@ -3,7 +3,6 @@ title: "Eploy"
 description: "Follow these steps to connect Eploy with StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure you have Admin privileges for your Eploy account.
@@ -182,7 +181,6 @@ In this example, the value would be: stackoneapidemo
   </Step>
 </Steps>
 
-<IntegrationFooter />
 
 ## Useful Links
 

--- a/connection-guides/ats/greenhouse.mdx
+++ b/connection-guides/ats/greenhouse.mdx
@@ -3,7 +3,6 @@ title: "Greenhouse"
 description: "If you have been directed to StackOne to integrate with Greenhouse, the following steps will help you understand the process and any necessary actions to configure successful integration."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   This guidance assumes you have Admin privileges for your Greenhouse account.
@@ -96,7 +95,6 @@ Enter the gathered details in the relevant inputs and proceed by clicking the Co
 ![Step 7](/images/greenhouse/F5PLzgbq4ZEu0KA2pDzz_i82EQ0cbhBzSMcna6Er9.gif)
 </Frame>
 
-<IntegrationFooter />
 
 ## Useful Links
 <Card title="API Reference" icon="link" href="https://developers.greenhouse.io/harvest.html">

--- a/connection-guides/ats/jazzhr.mdx
+++ b/connection-guides/ats/jazzhr.mdx
@@ -3,7 +3,6 @@ title: "JazzHR"
 description: "Follow these steps to connect JazzHR with StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure you have Admin privileges for your JazzHR account.
@@ -69,7 +68,6 @@ Upon reaching the Link Account page, enter the gathered details and proceed by c
   <img className='rounded-md' style={{ margin: '0 auto', border: '1px solid #efefef' }} alt="Link Account" src="/images/jazzhr/image6.png" />
 </Frame>
 
-<IntegrationFooter />
 
 ## Useful Links
 <Card title="API Reference" icon="link" href="https://www.resumatorapi.com/v1/">

--- a/connection-guides/ats/jobadder-oauth-client-credentials.mdx
+++ b/connection-guides/ats/jobadder-oauth-client-credentials.mdx
@@ -3,7 +3,6 @@ title: "JobAdder (OAuth Client Credentials)"
 description: "Follow these steps to connect JobAdder (OAuth Client Credentials) via the StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure that your JobAdder account has **Admin** privileges.
@@ -113,7 +112,6 @@ If you've been directed to StackOne to integrate with JobAdder, the following st
       </Frame>
   </Step>
 </Steps>
-<IntegrationFooter />
 
 ## Available data
 

--- a/connection-guides/ats/lever.mdx
+++ b/connection-guides/ats/lever.mdx
@@ -3,7 +3,6 @@ title: "Lever"
 description: "Follow these steps to connect Lever with StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure you have Admin privileges for your Lever account.
@@ -51,7 +50,6 @@ To continue, Accept the requested scopes.
   <img className='rounded-md' style={{ margin: '0 auto', border: '1px solid #efefef' }} alt="Scopes Page" src="/images/lever/image3.png" />
 </Frame>
 
-<IntegrationFooter />
 
 ## Useful Links
 <Card title="API Reference" icon="link" href="https://hire.lever.co/developers">

--- a/connection-guides/ats/logicmelon.mdx
+++ b/connection-guides/ats/logicmelon.mdx
@@ -3,7 +3,6 @@ title: "LogicMelon"
 description: "Follow these steps to connect LogicMelon with StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure you have Admin privileges for your LogicMelon account.
@@ -29,7 +28,6 @@ If you've been directed to StackOne to integrate with LogicMelon, the following 
   </Step>
 </Steps>
 
-<IntegrationFooter />
 
 ## Useful Links
 <Card title="API Reference" icon="link" href="https://api.logicmelon.com/soap/multiposter.asmx">

--- a/connection-guides/ats/mercury.mdx
+++ b/connection-guides/ats/mercury.mdx
@@ -3,7 +3,6 @@ title: "Mercury"
 description: "Follow these steps to connect Mercury via the StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure that your Mercury account has Admin privileges.
@@ -67,7 +66,6 @@ Proceed by clicking the Connect button.
     <img className='rounded-md' style={{ margin: '0 auto', border: '1px solid #efefef' }} alt="Enter Credentials" src="/images/mercury/image4.png" />
 </Frame>
 
-<IntegrationFooter />
 
 ## Useful Links
 <Card title="API Reference" icon="link" href="https://portal.wearemercury.com/knowledgebase/article/KA-01499/en-us">

--- a/connection-guides/ats/oraclehcm.mdx
+++ b/connection-guides/ats/oraclehcm.mdx
@@ -3,7 +3,6 @@ title: "Oracle HCM"
 description: "Follow these steps to connect Oracle HCM via the StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure you have Admin privileges for your Oracle HCM account.
@@ -102,7 +101,6 @@ You can find the REST Server URL, username, and password in the welcome email se
   </Step>
 </Steps>
 
-<IntegrationFooter />
 
 ## Available data
 

--- a/connection-guides/ats/pinpoint.mdx
+++ b/connection-guides/ats/pinpoint.mdx
@@ -3,7 +3,6 @@ title: "Pinpoint"
 description: "Follow these steps to connect Pinpoint with StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure you have Admin privileges for your Pinpoint account.
@@ -105,7 +104,6 @@ In this example, the value would be: stackone
   </Step>
 </Steps>
 
-<IntegrationFooter />
 
 ## Useful Links
 <Card title="API Reference" icon="link" href="https://developers.pinpointhq.com/docs/introduction">

--- a/connection-guides/ats/recruitee-marketplace-integration.mdx
+++ b/connection-guides/ats/recruitee-marketplace-integration.mdx
@@ -3,7 +3,6 @@ title: "Recruitee Marketplace Integration"
 description: "Follow these steps to connect the Recruitee Marketplace Integration with StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 
 ## Activate Marketplace Integration from Recruitee
@@ -44,7 +43,6 @@ import IntegrationFooter from "/snippets/integration-footer.mdx";
   </Step>
 </Steps>
 
-<IntegrationFooter />
 
 ## Useful Links
 <Card title="API Reference" icon="link" href="https://docs.recruitee.com/reference/post-partner">

--- a/connection-guides/ats/recruitee.mdx
+++ b/connection-guides/ats/recruitee.mdx
@@ -3,7 +3,6 @@ title: "Recruitee"
 description: "Follow these steps to connect Recruitee with StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure you have Admin privileges for your Recruitee account.
@@ -51,7 +50,6 @@ If you've been directed to StackOne to integrate with Recruitee, the following s
   </Step>
 </Steps>
 
-<IntegrationFooter />
 
 <Card title="Useful Links" icon="link" href="https://docs.recruitee.com">
   Recruitee API documentation: https://docs.recruitee.com

--- a/connection-guides/ats/sapsuccessfactors.mdx
+++ b/connection-guides/ats/sapsuccessfactors.mdx
@@ -3,7 +3,6 @@ title: "SAP SuccessFactors"
 description: "Follow these steps to connect SAP SuccessFactors with StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure you have Admin privileges for your SAP SuccessFactors account with permission for the Manage Integration Tools > Manage OAuth2 Client Applications.
@@ -157,7 +156,6 @@ If you've been directed to StackOne to integrate with SAP SuccessFactors, the fo
 Note: The integration may take up to 15 minutes to initially authenticate once the account has been connected. In the meantime, requests will return a 401: Unauthorized response.
 </Note>
 
-<IntegrationFooter />
 
 ## Useful Links
 <Card title="API Reference" icon="link" href="https://api.sap.com/products/SAPSuccessFactors/apis/all">

--- a/connection-guides/ats/smartrecruiters.mdx
+++ b/connection-guides/ats/smartrecruiters.mdx
@@ -3,7 +3,6 @@ title: "SmartRecruiters"
 description: "Follow these steps to connect SmartRecruiters with StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure you have Admin privileges for your SmartRecruiters account.
@@ -83,7 +82,6 @@ If you've been directed to StackOne to integrate with SmartRecruiters, the follo
   </Step>
 </Steps>
 
-<IntegrationFooter />
 
 ## Useful Links
 <Card title="API Reference" icon="link" href="https://developers.smartrecruiters.com/docs/the-smartrecruiters-platform">

--- a/connection-guides/ats/teamtailor-mfa.mdx
+++ b/connection-guides/ats/teamtailor-mfa.mdx
@@ -3,7 +3,6 @@ title: "Teamtailor"
 description: "Follow these steps to connect Teamtailor with StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure you have Admin privileges for your Teamtailor account.
@@ -202,7 +201,6 @@ Follow steps 2.1 to 2.2 inclusive to create the employee, you will then have to 
   </Step>
 </Steps>
 
-<IntegrationFooter />
 
 ## Useful Links
 <Card title="API Reference" icon="link" href="https://support.teamtailor.com/en/articles/5963369-use-our-teamtailor-api">

--- a/connection-guides/ats/teamtailor.mdx
+++ b/connection-guides/ats/teamtailor.mdx
@@ -3,7 +3,6 @@ title: "Teamtailor"
 description: "Follow these steps to connect Teamtailor with StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure you have Admin privileges for your Teamtailor account.
@@ -75,7 +74,6 @@ If you've been directed to StackOne to integrate with Teamtailor, the following 
   </Step>
 </Steps>
 
-<IntegrationFooter />
 
 ## Useful Links
 <Card title="API Reference" icon="link" href="https://support.teamtailor.com/en/articles/5963369-use-our-teamtailor-api">

--- a/connection-guides/ats/ukgpro.mdx
+++ b/connection-guides/ats/ukgpro.mdx
@@ -3,7 +3,6 @@ title: "UKG Pro ATS"
 description: "Follow these steps to connect UKG Pro with StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure you have Admin privileges for your UKG Pro account.
@@ -24,7 +23,6 @@ These are unique identifiers for your account. If you do not possess this inform
   <img className='rounded-md' style={{ margin: '0 auto', border: '1px solid #efefef' }} alt="StackOne Credentials" src="/images/ukgpro-ats/image1.png" />
 </Frame>
 
-<IntegrationFooter />
 
 ## Useful Links
 <Card title="API Reference" icon="link" href="https://developer.ukg.com/hcm/reference/welcome-to-the-ukg-pro-api">

--- a/connection-guides/ats/vincere.mdx
+++ b/connection-guides/ats/vincere.mdx
@@ -3,7 +3,6 @@ title: "Vincere"
 description: "Follow these steps to connect Vincere via the StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure you have Admin privileges for your Vincere account.
@@ -54,7 +53,6 @@ If you've been directed to StackOne to integrate with Vincere, the following ste
   </Step>
 </Steps>
 
-<IntegrationFooter />
 
 ## Available data
 

--- a/connection-guides/ats/workable.mdx
+++ b/connection-guides/ats/workable.mdx
@@ -3,7 +3,6 @@ title: "Workable"
 description: "If you've been directed to StackOne to integrate with Workable, the following steps will help you understand the process and any necessary actions to configure successful integration."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   This guidance assumes you have Super Admin privileges for your Workable account.
@@ -62,7 +61,6 @@ In StackOne, ensure the Workable integration is enabled. In <b>Accounts > Link A
   <img className='rounded-md' style={{ margin: '0 auto', border: '1px solid #efefef' }} alt="Connect Workable" src="/images/workable/image5.png" />
 </Frame>
 
-<IntegrationFooter />
 
 ## Useful Links
 <Card title="API Reference" icon="link" href="https://workable.readme.io/reference/">

--- a/connection-guides/ats/workday.mdx
+++ b/connection-guides/ats/workday.mdx
@@ -3,7 +3,6 @@ title: "Workday"
 description: "If you've been directed to StackOne to integrate with Workday, the following steps will help you understand the process and any necessary actions to configure successful integration."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   This guidance assumes you have Admin privileges for your Workday account.
@@ -227,7 +226,6 @@ You can use the Tenant and System User credentials you created in steps 1 & 2 to
   />
 </Frame>
 
-<IntegrationFooter />
 
 ## Useful Links
 

--- a/connection-guides/crm/attio.mdx
+++ b/connection-guides/crm/attio.mdx
@@ -3,7 +3,6 @@ title: "Attio"
 description: "Follow these steps to connect Attio with StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure you have Admin privileges for your Attio account.
@@ -82,7 +81,6 @@ If you've been directed to StackOne to integrate with Attio, the following steps
   </Step>
 </Steps>
 
-<IntegrationFooter />
 
 ## Useful Links
 <Card title="API Reference" icon="link" href="https://developers.attio.com/docs/getting-started">

--- a/connection-guides/crm/bullhorn.mdx
+++ b/connection-guides/crm/bullhorn.mdx
@@ -3,7 +3,6 @@ title: "Bullhorn"
 description: "Follow these steps to connect Bullhorn with StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure you have Admin privileges for your Bullhorn account.
@@ -42,7 +41,6 @@ You will need to contact Bullhorn support to "add the following redirect URI: `h
   </Step>
 </Steps>
 
-<IntegrationFooter />
 
 ## Useful Links
 <Card title="API Reference" icon="link" href="https://bullhorn.github.io/Getting-Started-with-REST">

--- a/connection-guides/crm/hubspot.mdx
+++ b/connection-guides/crm/hubspot.mdx
@@ -3,7 +3,6 @@ title: "HubSpot"
 description: "Follow these steps to connect HubSpot with StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure you have Admin privileges for your HubSpot account.
@@ -44,7 +43,6 @@ If you've been directed to StackOne to integrate with HubSpot, the following ste
   </Step>
 </Steps>
 
-<IntegrationFooter />
 
 <Card title="Useful Links" icon="link" href="https://developers.hubspot.com/docs/api/overview">
   HubSpot API documentation: https://developers.hubspot.com/docs/api/overview

--- a/connection-guides/crm/pipedrive-oauth.mdx
+++ b/connection-guides/crm/pipedrive-oauth.mdx
@@ -3,7 +3,6 @@ title: "Pipedrive - OAuth Authentication"
 description: "Follow these steps to connect Pipedrive via the StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure you have Admin privileges for your Pipedrive account.
@@ -97,4 +96,3 @@ If you've been directed to StackOne to integrate with Pipedrive, the following s
   </Step>
 </Steps>
 
-<IntegrationFooter />

--- a/connection-guides/crm/pipedrive.mdx
+++ b/connection-guides/crm/pipedrive.mdx
@@ -3,7 +3,6 @@ title: "Pipedrive"
 description: "Follow these steps to connect Pipedrive with StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure you have Admin privileges for your Pipedrive account.
@@ -53,4 +52,3 @@ Congratulations! You are now ready to connect with StackOne.
   </Step>
 </Steps>
 
-<IntegrationFooter />

--- a/connection-guides/crm/salesforce.mdx
+++ b/connection-guides/crm/salesforce.mdx
@@ -3,7 +3,6 @@ title: "Salesforce"
 description: "Follow these steps to connect Salesforce with StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure you have Admin privileges for your Salesforce account.
@@ -89,7 +88,6 @@ If you've been directed to StackOne to integrate with Salesforce, the following 
   </Step>
 </Steps>
 
-<IntegrationFooter />
 
 ## Useful Links
 <Card title="API Reference" icon="link" href="https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/quickstart.htm">

--- a/connection-guides/documents/confluence.mdx
+++ b/connection-guides/documents/confluence.mdx
@@ -3,7 +3,6 @@ title: "Confluence"
 description: "Follow these steps to connect Confluence via the StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure that your Confluence account has Org admin privileges.
@@ -97,7 +96,6 @@ Proceed by clicking the Connect button.
     <img className='rounded-md' style={{ margin: '0 auto', border: '1px solid #efefef' }} alt="Enter Credentials" src="/images/confluence/image9.png" />
 </Frame>
 
-<IntegrationFooter />
 
 ## Available data
 

--- a/connection-guides/documents/googledrive.mdx
+++ b/connection-guides/documents/googledrive.mdx
@@ -3,7 +3,6 @@ title: "GoogleDrive"
 description: "Follow these steps to connect GoogleDrive via the StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure that your GoogleDrive account has Admin or Owner privileges.
@@ -34,7 +33,6 @@ If you've been directed to StackOne to integrate with GoogleDrive, the following
     </Step>
 </Steps>
 
-<IntegrationFooter />
 
 ## Available data
 

--- a/connection-guides/documents/notion-oauth.mdx
+++ b/connection-guides/documents/notion-oauth.mdx
@@ -3,7 +3,6 @@ title: "Notion (OAuth)"
 description: "Follow these steps to connect Notion via the StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure that your Notion account has Workspace Owner privileges.
@@ -50,7 +49,6 @@ If you've been directed to StackOne to integrate with Notion, the following step
 </Steps>
 
 
-<IntegrationFooter />
 
 ## Available data
 

--- a/connection-guides/documents/notion.mdx
+++ b/connection-guides/documents/notion.mdx
@@ -3,7 +3,6 @@ title: "Notion"
 description: "Follow these steps to connect Notion via the StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure that your Notion account has Workspace Owner privileges.
@@ -109,7 +108,6 @@ Proceed by clicking the Connect button.
     <img className='rounded-md' style={{ margin: '0 auto', border: '1px solid #efefef' }} alt="Enter Credentials" src="/images/notion/image12.png" />
 </Frame>
 
-<IntegrationFooter />
 
 ## Available data
 

--- a/connection-guides/documents/onedrive.mdx
+++ b/connection-guides/documents/onedrive.mdx
@@ -3,7 +3,6 @@ title: "OneDrive"
 description: "Follow these steps to connect OneDrive via the StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure that your OneDrive account has Admin or Owner privileges.
@@ -95,7 +94,6 @@ If you've been directed to StackOne to integrate with OneDrive, the following st
   </Step>
 </Steps>
 
-<IntegrationFooter />
 
 ## Available data
 

--- a/connection-guides/documents/sharepoint.mdx
+++ b/connection-guides/documents/sharepoint.mdx
@@ -3,7 +3,6 @@ title: "Sharepoint"
 description: "Follow these steps to connect Sharepoint via the StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure that your Sharepoint account has Admin or Owner privileges.
@@ -95,7 +94,6 @@ If you've been directed to StackOne to integrate with Sharepoint, the following 
   </Step>
 </Steps>
 
-<IntegrationFooter />
 
 ## Available data
 

--- a/connection-guides/hris/adpworkforcenow.mdx
+++ b/connection-guides/hris/adpworkforcenow.mdx
@@ -3,7 +3,6 @@ title: "ADP Workforce Now"
 description: "Follow these steps to connect ADP Workforce Now with StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure you have Admin privileges for your ADP Workforce Now account.
@@ -85,7 +84,6 @@ Complete the integration with the following steps:
   <img className='rounded-md' style={{ margin: '0 auto', border: '1px solid #efefef' }} alt="StackOne Credentials" src="/images/adpworkforcenow/image1.png" />
 </Frame>
 
-<IntegrationFooter />
 
 ## Useful Links
 

--- a/connection-guides/hris/bamboohr-oauth.mdx
+++ b/connection-guides/hris/bamboohr-oauth.mdx
@@ -3,7 +3,6 @@ title: "BambooHR (OAuth)"
 description: "Follow these steps to successfully connect your BambooHR account to StackOne Hub using OAuth."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure that you have Admin privileges for your BambooHR account.
@@ -45,4 +44,3 @@ import IntegrationFooter from "/snippets/integration-footer.mdx";
   </Step>
 </Steps>
 
-<IntegrationFooter />

--- a/connection-guides/hris/bamboohr.mdx
+++ b/connection-guides/hris/bamboohr.mdx
@@ -3,7 +3,6 @@ title: "BambooHR"
 description: "Follow these steps to connect BambooHR with StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure you have Admin privileges for your BambooHR account.
@@ -85,4 +84,3 @@ If the connection form requires an API Key, follow these steps to generate it:
   </Step>
 </Steps>
 
-<IntegrationFooter />

--- a/connection-guides/hris/breathehr.mdx
+++ b/connection-guides/hris/breathehr.mdx
@@ -3,7 +3,6 @@ title: "Breathe HR"
 description: "Follow these steps to connect Breathe HR with StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure you have Admin privileges for your Breathe HR account.
@@ -47,7 +46,6 @@ If you've been directed to StackOne to integrate with Breathe HR, the following 
   </Step>
 </Steps>
 
-<IntegrationFooter />
 
 ## Useful Links
 <Card title="Getting Started" icon="link" href="https://developer.breathehr.com/documentation/getting_started">

--- a/connection-guides/hris/cascadehr.mdx
+++ b/connection-guides/hris/cascadehr.mdx
@@ -3,7 +3,6 @@ title: "CascadeHR"
 description: "Follow these steps to connect CascadeHR with StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure you have Admin privileges for your CascadeHR account.
@@ -40,7 +39,6 @@ If you've been directed to StackOne to integrate with CascadeHR, the following s
   </Step>
 </Steps>
 
-<IntegrationFooter />
 
 ## Useful Links
 <Card

--- a/connection-guides/hris/cezannehr.mdx
+++ b/connection-guides/hris/cezannehr.mdx
@@ -3,7 +3,6 @@ title: "Cezanne HR"
 description: "Follow these steps to connect Cezanne HR with StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure you have Admin privileges for your Cezanne HR account.
@@ -177,7 +176,6 @@ You can use the `Client ID`, `Client Secret`, and `Domain` to link your Cezanne 
   </Step>
 </Steps>
 
-<IntegrationFooter />
 
 ## Useful Links
 <Card title="API Reference" icon="link" href="https://api.cezannehr.com/">

--- a/connection-guides/hris/charliehr.mdx
+++ b/connection-guides/hris/charliehr.mdx
@@ -3,7 +3,6 @@ title: "Charlie HR"
 description: "Follow these steps to connect Charlie HR with StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure you have Admin privileges for your Charlie HR account.
@@ -47,7 +46,6 @@ If you've been directed to StackOne to integrate with Charlie HR, the following 
   </Step>
 </Steps>
 
-<IntegrationFooter />
 
 ## Useful Links
 <Card title="API Documentation" icon="link" href="https://www.charliehr.com/api_docs">

--- a/connection-guides/hris/deel-oauth.mdx
+++ b/connection-guides/hris/deel-oauth.mdx
@@ -3,7 +3,6 @@ title: "Deel (OAuth)"
 description: "Follow these steps to connect Deel via the StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure that your Deel account has Admin privileges.
@@ -87,7 +86,6 @@ This integration will authenticate on behalf of a registered application in Deel
         </Frame>
     </Step>
 </Steps>
-<IntegrationFooter />
 
 ## Available data
 

--- a/connection-guides/hris/deel-partner-oauth.mdx
+++ b/connection-guides/hris/deel-partner-oauth.mdx
@@ -3,7 +3,6 @@ title: "Deel (Partner OAuth)"
 description: "Follow these steps to connect Deel via the StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure that your Deel account has Admin privileges.
@@ -39,7 +38,6 @@ If you've been directed to StackOne to integrate with Deel, the following steps 
     </Step>
 </Steps>
 
-<IntegrationFooter />
 
 ## Available data
 

--- a/connection-guides/hris/deel.mdx
+++ b/connection-guides/hris/deel.mdx
@@ -3,7 +3,6 @@ title: "Deel"
 description: "Follow these steps to connect Deel via the StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure that your Deel account has Admin privileges.
@@ -64,7 +63,6 @@ Proceed by clicking **Connect**.
     <img className='rounded-md' style={{ margin: '0 auto', border: '1px solid #efefef' }} alt="Enter Credentials" src="/images/deel/image5.png" />
 </Frame>
 
-<IntegrationFooter />
 
 ## Available data
 

--- a/connection-guides/hris/employmenthero.mdx
+++ b/connection-guides/hris/employmenthero.mdx
@@ -3,7 +3,6 @@ title: "Employment Hero"
 description: "Follow these steps to connect Employment Hero via the StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure that your Employment Hero account has Admin privileges.
@@ -117,7 +116,6 @@ For example, if your URL is `https://secure.employmenthero.com/app/organisations
     </Step>
 </Steps>
 
-<IntegrationFooter />
 
 ## Useful Links
 <Card title="API Reference" icon="link" href="https://developer.employmenthero.com/api-references/">

--- a/connection-guides/hris/factorialhr-partner-oauth.mdx
+++ b/connection-guides/hris/factorialhr-partner-oauth.mdx
@@ -3,7 +3,6 @@ title: "Factorial HR - OAuth Authentication"
 description: "Follow these steps to connect Factorial HR with StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure you have Admin privileges for your Factorial HR account.
@@ -38,4 +37,3 @@ If you've been directed to StackOne to integrate with Factorial HR, the followin
 
 You'll get an instant "`Account connected`" success message and the opened tab will close.
 
-<IntegrationFooter />

--- a/connection-guides/hris/factorialhr.mdx
+++ b/connection-guides/hris/factorialhr.mdx
@@ -3,7 +3,6 @@ title: "Factorial HR"
 description: "Follow these steps to connect FactorialHr via the StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure you have Admin privileges for your Factorial HR account.
@@ -55,7 +54,6 @@ Proceed by clicking the Connect button.
     <img className='rounded-md' style={{ margin: '0 auto', border: '1px solid #efefef' }} alt="Enter Credentials" src="/images/factorialhr/image8.png" />
 </Frame>
 
-<IntegrationFooter />
 
 ## Available data
 

--- a/connection-guides/hris/fourth.mdx
+++ b/connection-guides/hris/fourth.mdx
@@ -3,7 +3,6 @@ title: "Fourth"
 description: "Follow these steps to connect Fourth via the StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure that your Fourth account has Admin privileges.
@@ -32,7 +31,6 @@ If you've been directed to StackOne to integrate with Fourth, the following step
   </Step>
 </Steps>
 
-<IntegrationFooter />
 
 ## Useful Links
 <Card title="API Reference" icon="link" href="https://developer.fourth.com/en-gb/docs/uk-employee-api/reference">

--- a/connection-guides/hris/gusto.mdx
+++ b/connection-guides/hris/gusto.mdx
@@ -3,7 +3,6 @@ title: "Gusto"
 description: "Follow these steps to connect Gusto with StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure you have Admin Payroll Role privileges for your Gusto account.
@@ -38,4 +37,3 @@ If you've been directed to StackOne to integrate with Gusto, the following steps
 
 You'll get an instant "`Account connected`" success message and the opened tab will close.
 
-<IntegrationFooter />

--- a/connection-guides/hris/haileyhr.mdx
+++ b/connection-guides/hris/haileyhr.mdx
@@ -3,7 +3,6 @@ title: "Hailey HR"
 description: "Follow these steps to connect Hailey HR with StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure you have Admin privileges for your Hailey HR account.
@@ -47,7 +46,6 @@ If you've been directed to StackOne to integrate with Hailey HR, the following s
   </Step>
 </Steps>
 
-<IntegrationFooter />
 
 ## Useful Links
 <Card title="API Reference" icon="link" href="https://api.haileyhr.app/docs/index.html">

--- a/connection-guides/hris/hibob-service-user.mdx
+++ b/connection-guides/hris/hibob-service-user.mdx
@@ -3,7 +3,6 @@ title: "Hibob - Service User"
 description: "Follow these steps to connect Hibob via the StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure you have Admin privileges for your Hibob account.
@@ -257,7 +256,6 @@ To check if a webhook is working correctly:
 
 For more details on webhook management, refer to [Hibob's Webhook Documentation](https://help.hibob.com/hc/en-us/articles/27276476753041-Manage-Webhooks).
 
-<IntegrationFooter />
 
 ## Useful Links
 <Card title="API Reference" icon="link" href="https://apidocs.hibob.com/docs">

--- a/connection-guides/hris/hibob.mdx
+++ b/connection-guides/hris/hibob.mdx
@@ -3,7 +3,6 @@ title: "Hibob - API Key Authentication"
 description: "Follow these steps to connect Hibob with StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure you have Admin privileges for your Hibob account.
@@ -57,7 +56,6 @@ If you've been directed to StackOne to integrate with Hibob, the following steps
   </Step>
 </Steps>
 
-<IntegrationFooter />
 
 ## Troubleshooting
 

--- a/connection-guides/hris/hrcloud.mdx
+++ b/connection-guides/hris/hrcloud.mdx
@@ -3,7 +3,6 @@ title: "HR Cloud"
 description: "Follow these steps to connect HR Cloud with StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure you have Admin privileges for your HR Cloud account.
@@ -61,7 +60,6 @@ If you've been directed to StackOne to integrate with HR Cloud, the following st
   </Step>
 </Steps>
 
-<IntegrationFooter />
 
 ## Useful Links
 <Card title="API Reference" icon="link" href="https://support.hrcloud.com/en/help-center/hr-cloud-api">

--- a/connection-guides/hris/humaans.mdx
+++ b/connection-guides/hris/humaans.mdx
@@ -3,7 +3,6 @@ title: "Humaans"
 description: "Follow these steps to connect Humaans with StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure you have API access permissions for your Humaans account.
@@ -63,4 +62,3 @@ This guidance assumes you have API access permissions for your Humaans account:
   </Step>
 </Steps>
 
-<IntegrationFooter />

--- a/connection-guides/hris/lattice-partner-oauth.mdx
+++ b/connection-guides/hris/lattice-partner-oauth.mdx
@@ -3,7 +3,6 @@ title: "Lattice (Partner OAuth)"
 description: "Follow these steps to connect Lattice via the StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
    Ensure that you have Admin privileges for your Lattice account.
@@ -92,4 +91,3 @@ This integration has the following [HRIS Resources](https://docs.stackone.com/re
   https://lattice.com/integrations-application
 </Card>
 
-<IntegrationFooter />

--- a/connection-guides/hris/oraclehcm.mdx
+++ b/connection-guides/hris/oraclehcm.mdx
@@ -3,7 +3,6 @@ title: "Oracle HCM"
 description: "Follow these steps to connect Oracle HCM with StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure you have Admin privileges for your Oracle HCM account.
@@ -99,7 +98,6 @@ You can find the REST Server URL, username, and password in the welcome email se
   </Step>
 </Steps>
 
-<IntegrationFooter />
 
 ## Useful Links
 <Card title="API Reference" icon="link" href="https://docs.oracle.com/en/cloud/saas/human-resources/23d/farws/index.html">

--- a/connection-guides/hris/oysterhr.mdx
+++ b/connection-guides/hris/oysterhr.mdx
@@ -3,7 +3,6 @@ title: "Oyster HR"
 description: "Follow these steps to connect Oyster HR with StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure you have Admin privileges for your Oyster HR account.
@@ -126,7 +125,6 @@ You can use the `Client ID`, `Client Secret`, and `Authorization URL` to link yo
   </Step>
 </Steps>
 
-<IntegrationFooter />
 
 ## Useful Links
 <Card title="API Reference" icon="link" href="https://docs.oysterhr.com/reference/post_oauth2-token-1">

--- a/connection-guides/hris/payfit.mdx
+++ b/connection-guides/hris/payfit.mdx
@@ -3,7 +3,6 @@ title: "Payfit"
 description: "Follow these steps to connect Payfit via the StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure that your Payfit account has Admin privileges.
@@ -61,7 +60,6 @@ Proceed by clicking the Connect button.
     <img className='rounded-md' style={{ margin: '0 auto', border: '1px solid #efefef' }} alt="Enter Credentials" src="/images/payfit/image3.png" />
 </Frame>
 
-<IntegrationFooter />
 
 ## Useful Links
 <Card title="API Reference" icon="link" href="https://developers.payfit.io/docs/authentication-via-api-key">

--- a/connection-guides/hris/paylocity.mdx
+++ b/connection-guides/hris/paylocity.mdx
@@ -3,7 +3,6 @@ title: "Paylocity"
 description: "Follow these steps to connect Paylocity via the StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure that your Paylocity account has Admin privileges.
@@ -32,7 +31,6 @@ If you've been directed to StackOne to integrate with Paylocity, the following s
   </Step>
 </Steps>
 
-<IntegrationFooter />
 
 ## Useful Links
 <Card title="API Reference" icon="link" href="https://developer.paylocity.com/integrations/reference">

--- a/connection-guides/hris/personio-custom-integrations.mdx
+++ b/connection-guides/hris/personio-custom-integrations.mdx
@@ -3,7 +3,6 @@ title: "Personio - Custom Integrations"
 description: "Follow these steps to connect Personio with StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure you have Admin privileges for your Personio account.
@@ -97,4 +96,3 @@ NOTE: Copy your API credentials – client ID and client secret to a safe place.
   </Step>
 </Steps>
 
-<IntegrationFooter />

--- a/connection-guides/hris/personio.mdx
+++ b/connection-guides/hris/personio.mdx
@@ -3,7 +3,6 @@ title: "Personio"
 description: "Follow these steps to connect Personio with StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure you have Admin privileges for your Personio account.
@@ -97,7 +96,6 @@ This guidance assumes you have Admin privileges for your Personio account.
   </Step>
 </Steps>
 
-<IntegrationFooter />
 
 ## Useful Links
 <Card title="API Reference" icon="link" href="https://developer.personio.de/docs/getting-started-with-the-personio-api">

--- a/connection-guides/hris/sage.mdx
+++ b/connection-guides/hris/sage.mdx
@@ -3,7 +3,6 @@ title: "Sage HR"
 description: "Follow these steps to connect Sage HR with StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure you have Admin privileges for your Sage HR account.
@@ -52,7 +51,6 @@ This guidance assumes you have Admin privileges for your Sage HR account.
   </Step>
 </Steps>
 
-<IntegrationFooter />
 
 ## Useful Links
 <Card title="API Reference" icon="link" href="https://developer.sage.com/hr/get-started/">

--- a/connection-guides/hris/sapsuccessfactors.mdx
+++ b/connection-guides/hris/sapsuccessfactors.mdx
@@ -3,7 +3,6 @@ title: "SAP SuccessFactors"
 description: "Follow these steps to connect SAP SuccessFactors with StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure you have Admin privileges for your SAP SuccessFactors account with permission for the Manage Integration Tools > Manage OAuth2 Client Applications.
@@ -157,7 +156,6 @@ If you've been directed to StackOne to integrate with SAP SuccessFactors, the fo
 Note: The integration may take up to 15 minutes to initially authenticate once the account has been connected. In the meantime, requests will return a 401: Unauthorized response.
 </Note>
 
-<IntegrationFooter />
 
 ## Useful Links
 <Card title="API Reference" icon="link" href="https://api.sap.com/products/SAPSuccessFactors/apis/all">

--- a/connection-guides/hris/simployer.mdx
+++ b/connection-guides/hris/simployer.mdx
@@ -3,7 +3,6 @@ title: "Simployer One"
 description: "Follow these steps to connect Simployer One via the StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure you are an Owner in your Simployer One account. You need Owner permissions to generate access tokens.
@@ -62,7 +61,6 @@ If you've been directed to StackOne to integrate with Simployer One, the followi
   </Step>
 </Steps>
 
-<IntegrationFooter />
 
 ## Useful Links
 <Card title="API Documentation" icon="link" href="https://docs.alexishr.com">

--- a/connection-guides/hris/staffologyhr.mdx
+++ b/connection-guides/hris/staffologyhr.mdx
@@ -3,7 +3,6 @@ title: "Staffology HR"
 description: "Follow these steps to connect Staffology HR via the StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure you have Admin privileges for your Staffology HR account.
@@ -131,7 +130,6 @@ This guidance assumes you have Admin privileges for your Staffology HR account.
   </Step>
 </Steps>
 
-<IntegrationFooter />
 
 ## Useful Links
 

--- a/connection-guides/hris/ukgpro.mdx
+++ b/connection-guides/hris/ukgpro.mdx
@@ -3,7 +3,6 @@ title: "UKG Pro"
 description: "Follow these steps to connect UKG Pro with StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure you have Admin privileges for your UKG Pro account.
@@ -197,7 +196,6 @@ This guidance assumes you have Admin privileges for your UKG Pro account.
   </Step>
 </Steps>
 
-<IntegrationFooter />
 
 ## Useful Links
 

--- a/connection-guides/hris/ukgprowfm.mdx
+++ b/connection-guides/hris/ukgprowfm.mdx
@@ -3,7 +3,6 @@ title: "UKG Pro Workforce Management"
 description: "Follow these steps to connect UKG Pro Workforce Management via the StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   This guidance assumes you have admin access to UKG Pro Workforce Management and can create or request API credentials.
@@ -57,7 +56,6 @@ UKG Pro Workforce Management uses an OAuth LDAP (password-based) flow. You'll ne
   </Step>
 </Steps>
 
-<IntegrationFooter />
 
 ## Available data
 

--- a/connection-guides/hris/ukgready-oauth-client-credentials.mdx
+++ b/connection-guides/hris/ukgready-oauth-client-credentials.mdx
@@ -3,7 +3,6 @@ title: "UKG Ready (OAuth Client Credentials)"
 description: "Follow these steps to connect UKG Ready (OAuth Client Credentials) with StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure you have Admin privileges for your UKG Ready account.
@@ -397,7 +396,6 @@ If you've been directed to StackOne to integrate with UKG Ready (OAuth Client Cr
 </Steps>
 
 
-<IntegrationFooter />
 
 ## Useful Links
 

--- a/connection-guides/hris/ukgready-oauth.mdx
+++ b/connection-guides/hris/ukgready-oauth.mdx
@@ -3,7 +3,6 @@ title: "UKG Ready (OAuth)"
 description: "Follow these steps to connect UKG Ready (OAuth) with StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure you have Admin privileges for your UKG Ready account.
@@ -256,7 +255,6 @@ If you've been directed to StackOne to integrate with UKG Ready (OAuth), the fol
 </Steps>
 
 
-<IntegrationFooter />
 
 ## Useful Links
 

--- a/connection-guides/hris/workday-raas.mdx
+++ b/connection-guides/hris/workday-raas.mdx
@@ -3,8 +3,6 @@ title: "Workday RaaS"
 description: "Follow these steps to connect Workday via Report as a Service (RaaS) successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx"
-
 <Warning>
   This guidance assumes you have administrative privileges for your Workday account.
 </Warning>

--- a/connection-guides/hris/workday.mdx
+++ b/connection-guides/hris/workday.mdx
@@ -3,7 +3,6 @@ title: "Workday"
 description: "If you've been directed to StackOne to integrate with Workday, the following steps will help you understand the process and any necessary actions to configure successful integration."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   This guidance assumes you have Admin privileges for your Workday account.
@@ -208,7 +207,6 @@ Click **Connect**.
   <img className='rounded-md' style={{ margin: '0 auto', border: '1px solid #efefef' }} alt="Linking your Account" src="/images/workday/image9.png" />
 </Frame>
 
-<IntegrationFooter />
 
 <Card title="Useful Links" icon="link" href="https://doc.workday.com">
     https://doc.workday.com

--- a/connection-guides/hris/workday_OAuth2.mdx
+++ b/connection-guides/hris/workday_OAuth2.mdx
@@ -3,7 +3,6 @@ title: "Workday (OAuth)"
 description: "If you've been directed to StackOne to integrate with Workday, the following steps will help you understand the process and any necessary actions to configure successful integration."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   This guidance assumes you have Admin privileges for your Workday account.
@@ -425,7 +424,6 @@ Click **Connect**.
   />
 </Frame>
 
-<IntegrationFooter />
 
 <Card title="Useful Links" icon="link" href="https://doc.workday.com">
   https://doc.workday.com

--- a/connection-guides/hris/workday_wql.mdx
+++ b/connection-guides/hris/workday_wql.mdx
@@ -3,7 +3,6 @@ title: "Workday WQL (OAuth)"
 description: "Follow these steps to understand the process and actions required for a successful connection."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   This guidance assumes you have administrator privileges for your Workday account.
@@ -544,7 +543,6 @@ Click **Connect**.
 </Frame>
 
 
-<IntegrationFooter />
 
 <Card title="Useful Links" icon="link" href="https://doc.workday.com">
   https://doc.workday.com

--- a/connection-guides/hris/zelt.mdx
+++ b/connection-guides/hris/zelt.mdx
@@ -3,7 +3,6 @@ title: "Zelt"
 description: "Follow these steps to connect Zelt with StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure you have Admin privileges for your Zelt account.
@@ -103,4 +102,3 @@ If you've been directed to StackOne to integrate with Zelt, the following steps 
   </Step>
 </Steps>
 
-<IntegrationFooter />

--- a/connection-guides/iam/15five.mdx
+++ b/connection-guides/iam/15five.mdx
@@ -3,7 +3,6 @@ title: "15Five - IAM"
 description: "Follow these steps to connect 15Five via the StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure you have Admin privileges within your 15Five account.
@@ -75,7 +74,6 @@ This guidance assumes that you are an Administrator within 15Five.
   
 </Steps>
 
-<IntegrationFooter />
 
 
 ## Available data

--- a/connection-guides/iam/1password.mdx
+++ b/connection-guides/iam/1password.mdx
@@ -3,7 +3,6 @@ title: "1Password"
 description: "Follow these steps to connect 1Password via the StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure you have Administrator privileges within your 1Password account.
@@ -119,7 +118,6 @@ Your SCIM Bridge must be fully configured for this integration. You can check th
   </Step>
 </Steps>
 
-<IntegrationFooter />
 
 
 ## Available data

--- a/connection-guides/iam/aircall.mdx
+++ b/connection-guides/iam/aircall.mdx
@@ -3,7 +3,6 @@ title: "Aircall"
 description: "Follow these steps to connect Aircall via the StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure that your Aircall account has Admin or Owner privileges.
@@ -74,7 +73,6 @@ If you've been directed to StackOne to integrate with Aircall, the following ste
   </Step>
 </Steps>
 
-<IntegrationFooter />
 
 ## Available data
 

--- a/connection-guides/iam/ansibletower.mdx
+++ b/connection-guides/iam/ansibletower.mdx
@@ -3,7 +3,6 @@ title: "Ansible Tower"
 description: "Follow these steps to connect Ansible Tower via the StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure that your Ansible Tower account has Administrator privileges.
@@ -83,7 +82,6 @@ This connection will authenticate on behalf of a registered Application in Ansib
   </Step>
 </Steps>
 
-<IntegrationFooter />
 
 ## Available data
 

--- a/connection-guides/iam/anthropic.mdx
+++ b/connection-guides/iam/anthropic.mdx
@@ -3,7 +3,6 @@ title: "Anthropic"
 description: "Follow these steps to connect Anthropic via the StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure that your Anthropic account has **Admin** privileges within your Organization.
@@ -71,7 +70,6 @@ Proceed by clicking the Connect button.
     <img className='rounded-md' style={{ margin: '0 auto', border: '1px solid #efefef' }} alt="Enter Credentials" src="/images/anthropic/image6.png" />
 </Frame>
 
-<IntegrationFooter />
 
 ## Available data
 

--- a/connection-guides/iam/articulate.mdx
+++ b/connection-guides/iam/articulate.mdx
@@ -3,7 +3,6 @@ title: "Articulate - Reach 360"
 description: "Follow these steps to connect Articulate - Reach 360 via the StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure that your Articulate - Reach 360 account has Administrator privileges.
@@ -92,7 +91,6 @@ Upon reaching the Link Account page, enter your **API Key** from the previous st
 Proceed by clicking the Connect button.
 </Step>
 
-<IntegrationFooter />
 
 ## Available data
 

--- a/connection-guides/iam/ashby.mdx
+++ b/connection-guides/iam/ashby.mdx
@@ -3,7 +3,6 @@ title: "Ashby"
 description: "If you have been directed to StackOne to integrate with Ashby, the following steps will help you understand the process and any necessary actions to configure successful integration."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   The following guidance assumes you have Admin privileges for your Ashby
@@ -70,7 +69,6 @@ Upon reaching the Link Account page, enter the generated API key and proceed by 
   />
 </Frame>
 
-<IntegrationFooter />
 
 
 ## Available data

--- a/connection-guides/iam/attio.mdx
+++ b/connection-guides/iam/attio.mdx
@@ -3,7 +3,6 @@ title: "Attio"
 description: "Follow these steps to connect Attio with StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure you have Admin privileges for your Attio account.
@@ -82,7 +81,6 @@ If you've been directed to StackOne to integrate with Attio, the following steps
   </Step>
 </Steps>
 
-<IntegrationFooter />
 
 
 ## Available data

--- a/connection-guides/iam/autodesk.mdx
+++ b/connection-guides/iam/autodesk.mdx
@@ -3,7 +3,6 @@ title: "Autodesk - IAM"
 description: "Follow these steps to connect Autodesk via the StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure you have Admin privileges for your Autodesk account.
@@ -163,7 +162,6 @@ This guidance assumes that you are a Primary Admin or Secondary Admin within Aut
   </Step>
 </Steps>
 
-<IntegrationFooter />
 
 
 ## Available data

--- a/connection-guides/iam/bitwarden.mdx
+++ b/connection-guides/iam/bitwarden.mdx
@@ -3,7 +3,6 @@ title: "Bitwarden"
 description: "Follow these steps to connect Bitwarden via the StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure you have Admin or Owner privileges for your Bitwarden Enterprise Organization.
@@ -71,7 +70,6 @@ For example, given the URL: `https://vault.bitwarden.eu/#/organizations/abc123/m
   </Step>
 </Steps>
 
-<IntegrationFooter />
 
 
 ## Available data

--- a/connection-guides/iam/box.mdx
+++ b/connection-guides/iam/box.mdx
@@ -3,7 +3,6 @@ title: "Box"
 description: "Follow these steps to connect Box via the StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure that your Box account has Admin privileges and has **2-Step Verification** enabled in your [Box Account Settings](https://app.box.com/account/developer).
@@ -158,7 +157,6 @@ This connection will authenticate on behalf of a registered Application in Box.
 
 </Steps>
 
-<IntegrationFooter />
 
 ## Available data
 

--- a/connection-guides/iam/bullhorn.mdx
+++ b/connection-guides/iam/bullhorn.mdx
@@ -3,7 +3,6 @@ title: "Bullhorn"
 description: "Follow these steps to connect Bullhorn with StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure you have Admin privileges for your Bullhorn account.
@@ -42,7 +41,6 @@ You will need to contact Bullhorn support to "add the following redirect URI: `h
   </Step>
 </Steps>
 
-<IntegrationFooter />
 
 ## Available data
 

--- a/connection-guides/iam/canva.mdx
+++ b/connection-guides/iam/canva.mdx
@@ -3,7 +3,6 @@ title: "Canva"
 description: "Follow these steps to connect Canva via the StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure you have Admin privileges for your Canva Teams account.
@@ -65,7 +64,6 @@ This guidance assumes that you are an Admin within Canva Teams.
   </Step>
 </Steps>
 
-<IntegrationFooter />
 
 
 ## Available data

--- a/connection-guides/iam/checkmk.mdx
+++ b/connection-guides/iam/checkmk.mdx
@@ -3,7 +3,6 @@ title: "Checkmk"
 description: "Follow these steps to connect Checkmk with StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure you have Administrator privileges for your Checkmk Dashboard.
@@ -69,7 +68,6 @@ You will need to provide a Username, Password and Site URL. It is recommended th
   </Step>
 </Steps>
 
-<IntegrationFooter />
 
 
 ## Available data

--- a/connection-guides/iam/cloudways.mdx
+++ b/connection-guides/iam/cloudways.mdx
@@ -3,7 +3,6 @@ title: "Cloudways"
 description: "Follow these steps to connect Cloudways via the StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure that your Cloudways account has Owner or Admin privileges.
@@ -72,7 +71,6 @@ Log in to your Cloudways account at [https://platform.cloudways.com/login](https
     </Frame>
 
 
-<IntegrationFooter />
 
 ## Available data
 

--- a/connection-guides/iam/contentful.mdx
+++ b/connection-guides/iam/contentful.mdx
@@ -3,7 +3,6 @@ title: "Contentful"
 description: "Follow these steps to connect Contentful via the StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure you have Admin privileges within your Contentful organization.
@@ -122,7 +121,6 @@ This CMA Token is required to access Contentful's Content Management API.
   </Step>
 </Steps>
 
-<IntegrationFooter />
 
 
 ## Available data

--- a/connection-guides/iam/databricks-oauth.mdx
+++ b/connection-guides/iam/databricks-oauth.mdx
@@ -3,7 +3,6 @@ title: "Databricks (OAuth)"
 description: "Follow these steps to connect Databricks via the StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure that your Databricks account has Account Admin privileges.
@@ -107,7 +106,6 @@ You may be prompted to log in to your Databricks account to authorize the connec
   <img className='rounded-md' style={{ margin: '0 auto', border: '1px solid #efefef' }} alt="Connecting with StackOne" src="/images/databricks/image7.png" />
 </Frame>
 
-<IntegrationFooter />
 
 ## Available data
 

--- a/connection-guides/iam/databricks.mdx
+++ b/connection-guides/iam/databricks.mdx
@@ -3,7 +3,6 @@ title: "Databricks"
 description: "Follow these steps to connect Databricks via the StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   This authentication method requires User Provisioning to be enabled and set up within your Databricks account. 
@@ -62,7 +61,6 @@ Click the down arrow next to your username in the top-right corner. In the drop-
   </Step>
 </Steps>
 
-<IntegrationFooter />
 
 ## Available data
 

--- a/connection-guides/iam/dialpad.mdx
+++ b/connection-guides/iam/dialpad.mdx
@@ -3,7 +3,6 @@ title: "Dialpad - API Key Authentication"
 description: "Follow these steps to connect Dialpad via the StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure you are an Company Admin in your Dialpad account.
@@ -68,7 +67,6 @@ This guidance assumes that you are an Company Admin within Dialpad.
   </Step>
 </Steps>
  
-<IntegrationFooter />
 
 
 ## Available data

--- a/connection-guides/iam/dixa.mdx
+++ b/connection-guides/iam/dixa.mdx
@@ -3,7 +3,6 @@ title: "Dixa - IAM"
 description: "Follow these steps to connect Dixa via the StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure you have Admin privileges within your Dixa organization.
@@ -64,7 +63,6 @@ This guidance assumes that you are an Administrator within Dixa.
   </Step>
 </Steps>
 
-<IntegrationFooter />
 
 
 ## Available data

--- a/connection-guides/iam/domo.mdx
+++ b/connection-guides/iam/domo.mdx
@@ -3,7 +3,6 @@ title: "Domo"
 description: "Follow these steps to connect Domo via the StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure you have the Create API OAuth Clients Grant assigned to your Domo Role. This is available in the default Domo Roles: Admin, Privileged, Editor, Participant, and Social.
@@ -63,7 +62,6 @@ If you've been directed to StackOne to integrate with Domo, the following steps 
   </Step>
 </Steps>
 
-<IntegrationFooter />
 
 
 ## Available data

--- a/connection-guides/iam/dropbox.mdx
+++ b/connection-guides/iam/dropbox.mdx
@@ -3,7 +3,6 @@ title: "Dropbox"
 description: "Follow these steps to connect Dropbox via the StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure you have Admin privileges within your Dropbox account.
@@ -83,7 +82,6 @@ If you've been directed to StackOne to integrate with Dropbox, the following ste
   </Step>
 </Steps>
 
-<IntegrationFooter />
 
 
 ## Available data

--- a/connection-guides/iam/dropboxsign.mdx
+++ b/connection-guides/iam/dropboxsign.mdx
@@ -3,7 +3,6 @@ title: "Dropbox Sign"
 description: "If you have been directed to StackOne to integrate with Dropbox Sign, the following steps will help you understand the process and any necessary actions to configure successful integration."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   The following guidance assumes you have Admin privileges for your Dropbox Sign account.
@@ -52,7 +51,6 @@ Upon reaching the Link Account page, enter the generated API key and proceed by 
   />
 </Frame>
 
-<IntegrationFooter />
 
 
 ## Available data

--- a/connection-guides/iam/duo.mdx
+++ b/connection-guides/iam/duo.mdx
@@ -3,7 +3,6 @@ title: "Duo"
 description: "Follow these steps to connect Duo via the StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure you have the Owner role within Duo.
@@ -89,7 +88,6 @@ If you've been directed to StackOne to integrate with Duo, the following steps w
   </Step>
 </Steps>
 
-<IntegrationFooter />
 
 
 ## Available data

--- a/connection-guides/iam/egnyte.mdx
+++ b/connection-guides/iam/egnyte.mdx
@@ -3,7 +3,6 @@ title: "Egnyte"
 description: "Follow these steps to connect Egnyte via the StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure you have Admin privileges within your Egnyte account and an Egnyte for Developers account.
@@ -93,7 +92,6 @@ This connection will be authenticated on behalf of a private application you wil
   </Step>
 </Steps>
 
-<IntegrationFooter />
 
 
 ## Available data

--- a/connection-guides/iam/elastic.mdx
+++ b/connection-guides/iam/elastic.mdx
@@ -3,7 +3,6 @@ title: "Elastic"
 description: "Follow these steps to connect Elastic via the StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure you have Admin privileges within your Elastic organization.
@@ -85,7 +84,6 @@ This guidance assumes that you are an Organization Admin within Elastic.
   </Step>
 </Steps>
 
-<IntegrationFooter />
 
 
 ## Available data

--- a/connection-guides/iam/envoy.mdx
+++ b/connection-guides/iam/envoy.mdx
@@ -3,7 +3,6 @@ title: "Envoy"
 description: "Follow these steps to connect Envoy via the StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure you have Admin privileges within your Envoy organization.
@@ -65,7 +64,6 @@ This connection will be authenticated on behalf of a private app you will create
   </Step>
 </Steps>
 
-<IntegrationFooter />
 
 
 ## Available data

--- a/connection-guides/iam/fivetran.mdx
+++ b/connection-guides/iam/fivetran.mdx
@@ -3,7 +3,6 @@ title: "Fivetran"
 description: "Follow these steps to connect Fivetran via the StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure you have Admin privileges within your Fivetran account.
@@ -57,7 +56,6 @@ This guidance assumes that you are an Account Administrator in Fivetran.
   </Step>
 </Steps>
 
-<IntegrationFooter />
 
 
 ## Available data

--- a/connection-guides/iam/freshsales.mdx
+++ b/connection-guides/iam/freshsales.mdx
@@ -3,7 +3,6 @@ title: "Freshsales"
 description: "Follow these steps to connect Freshsales via the StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure you have Admin privileges within your Freshsales organization.
@@ -63,7 +62,6 @@ This guidance assumes that you are an Organization Admin within Freshsales.
   </Step>
 </Steps>
 
-<IntegrationFooter />
 
 
 ## Available data

--- a/connection-guides/iam/github.mdx
+++ b/connection-guides/iam/github.mdx
@@ -3,7 +3,6 @@ title: "Github"
 description: "Follow these steps to connect Github via the StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure that your Github account has the Owner privileges in the organization you are making connection with.
@@ -126,7 +125,6 @@ If you've been directed to StackOne to integrate with Github, the following step
   </Step>
 </Steps>
 
-<IntegrationFooter />
 
 ## Available data
 

--- a/connection-guides/iam/gong.mdx
+++ b/connection-guides/iam/gong.mdx
@@ -3,7 +3,6 @@ title: "Gong"
 description: "Follow these steps to connect Gong via the StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure you have Business Admins privileges within your Gong account.
@@ -84,7 +83,6 @@ If you've been directed to StackOne to integrate with Gong, the following steps 
   </Step>
 </Steps>
 
-<IntegrationFooter />
 
 
 ## Available data

--- a/connection-guides/iam/googleworkspace-oauth.mdx
+++ b/connection-guides/iam/googleworkspace-oauth.mdx
@@ -3,7 +3,6 @@ title: "Google Workspace"
 description: "Follow these steps to connect Google Workspace via the StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure that your Google Workspace account has Admin or Owner privileges.
@@ -214,7 +213,6 @@ Google requires configuring a consent screen to be displayed when granting appli
   </Step>
 </Steps>
 
-<IntegrationFooter />
 
 ## Available data
 

--- a/connection-guides/iam/greenhouse.mdx
+++ b/connection-guides/iam/greenhouse.mdx
@@ -3,7 +3,6 @@ title: "Greenhouse"
 description: "If you have been directed to StackOne to integrate with Greenhouse, the following steps will help you understand the process and any necessary actions to configure successful integration."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   This guidance assumes you have Admin privileges for your Greenhouse account.
@@ -70,7 +69,6 @@ Enter the gathered details in the relevant inputs and proceed by clicking the Co
 ![Step 7](/images/greenhouse/image7.png)
 </Frame>
 
-<IntegrationFooter />
 
 
 ## Available data

--- a/connection-guides/iam/harvest.mdx
+++ b/connection-guides/iam/harvest.mdx
@@ -3,7 +3,6 @@ title: "Harvest"
 description: "Follow these steps to connect Harvest via the StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure you have Admin privileges within your Harvest account.
@@ -67,7 +66,6 @@ This guidance assumes that you are an Administrator within Harvest.
   </Step>
 </Steps>
 
-<IntegrationFooter />
 
 
 ## Available data

--- a/connection-guides/iam/intercom.mdx
+++ b/connection-guides/iam/intercom.mdx
@@ -3,7 +3,6 @@ title: "Intercom"
 description: "Follow these steps to connect Intercom via the StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure you have Admin privileges within your Intercom account.
@@ -68,7 +67,6 @@ This connection will be authenticated on behalf of a Private Intercom App you wi
   </Step>
 </Steps>
 
-<IntegrationFooter />
 
 
 ## Available data

--- a/connection-guides/iam/ironclad.mdx
+++ b/connection-guides/iam/ironclad.mdx
@@ -3,7 +3,6 @@ title: "Ironclad"
 description: "Follow these steps to connect Ironclad via the StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure that your Ironclad account has Administrator privileges.
@@ -64,7 +63,6 @@ Upon reaching the Link Account page, enter the **API Token** from the previous s
 
 Proceed by clicking the Connect button.
 
-<IntegrationFooter />
 
 ## Available data
 

--- a/connection-guides/iam/jetbrains.mdx
+++ b/connection-guides/iam/jetbrains.mdx
@@ -3,7 +3,6 @@ title: "Jetbrains"
 description: "Follow these steps to connect Jetbrains via the StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure you have Admin privileges within your Jetbrains Space account.
@@ -93,7 +92,6 @@ This guidance assumes that you are a System Administrator in your Jetbrains Spac
   </Step>
 </Steps>
 
-<IntegrationFooter />
 
 
 ## Available data

--- a/connection-guides/iam/kameleoon-oauth.mdx
+++ b/connection-guides/iam/kameleoon-oauth.mdx
@@ -3,7 +3,6 @@ title: "Kameleoon"
 description: "Follow these steps to connect Kameleoon via the StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure that your Kameleoon account has **Admin** or **Super Admin** privileges.
@@ -62,7 +61,6 @@ This integration will authenticate on behalf of your Kameleoon user API credenti
         <img className='rounded-md' style={{ margin: '0 auto', border: '1px solid #efefef' }} alt="Enter Credentials" src="/images/kameleoon/image5.png" />
     </Frame>
 
-<IntegrationFooter />
 
 ## Available data
 

--- a/connection-guides/iam/klaviyo.mdx
+++ b/connection-guides/iam/klaviyo.mdx
@@ -3,7 +3,6 @@ title: "Klaviyo"
 description: "Follow these steps to connect Klaviyo via the StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure you have a paid Klaviyo plan and that you are an Admin or Owner in your Klaviyo account.
@@ -65,7 +64,6 @@ If you've been directed to StackOne to integrate with Klaviyo, the following ste
   </Step>
 </Steps>
 
-<IntegrationFooter />
 
 
 ## Available data

--- a/connection-guides/iam/lacework.mdx
+++ b/connection-guides/iam/lacework.mdx
@@ -3,7 +3,6 @@ title: "Lacework"
 description: "Follow these steps to connect Lacework with StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure you have Admin privileges for your Lacework account.
@@ -75,7 +74,6 @@ If you've been directed to StackOne to integrate with Lacework, the following st
   </Step>
 </Steps>
 
-<IntegrationFooter />
 
 
 ## Available data

--- a/connection-guides/iam/lastpass.mdx
+++ b/connection-guides/iam/lastpass.mdx
@@ -3,7 +3,6 @@ title: "LastPass"
 description: "Follow these steps to connect LastPass via the StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure you have Admin privileges for your LastPass Enterprise account.
@@ -86,7 +85,6 @@ This token is required for accessing the LastPass Enterprise API.
   </Step>
 </Steps>
 
-<IntegrationFooter />
 
 
 ## Available data

--- a/connection-guides/iam/lattice.mdx
+++ b/connection-guides/iam/lattice.mdx
@@ -3,7 +3,6 @@ title: "Lattice"
 description: "Follow these steps to connect Lattice with StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure you have Super admin privileges for your Lattice account.
@@ -54,7 +53,6 @@ If you've been directed to StackOne to integrate with Lattice, the following ste
   </Step>
 </Steps>
 
-<IntegrationFooter />
 
 
 ## Available data

--- a/connection-guides/iam/leapsome.mdx
+++ b/connection-guides/iam/leapsome.mdx
@@ -3,7 +3,6 @@ title: "Leapsome"
 description: "Follow these steps to connect Leapsome via the StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure you have Admin privileges for your Leapsome account.
@@ -83,7 +82,6 @@ If you've been directed to StackOne to integrate with Leapsome, the following st
   </Step>
 </Steps>
 
-<IntegrationFooter />
 
 
 ## Available data

--- a/connection-guides/iam/lever.mdx
+++ b/connection-guides/iam/lever.mdx
@@ -3,7 +3,6 @@ title: "Lever"
 description: "Follow these steps to connect Lever with StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure you have Admin privileges for your Lever account.
@@ -51,7 +50,6 @@ To continue, Accept the requested scopes.
   <img className='rounded-md' style={{ margin: '0 auto', border: '1px solid #efefef' }} alt="Scopes Page" src="/images/lever/image3.png" />
 </Frame>
 
-<IntegrationFooter />
 
 
 ## Available data

--- a/connection-guides/iam/make.mdx
+++ b/connection-guides/iam/make.mdx
@@ -3,7 +3,6 @@ title: "Make"
 description: "Follow these steps to connect Make via the StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure that your Make account has Owner or Admin privileges.
@@ -122,7 +121,6 @@ Given the URL `https://eu1.make.com/organizations/1234567/dashboard`, the **Orga
       <img className='rounded-md' style={{ margin: '0 auto', border: '1px solid #efefef' }} alt="Enter Credentials" src="/images/make/image9.png" />
     </Frame>
 
-<IntegrationFooter />
 
 ## Available data
 

--- a/connection-guides/iam/meistertask-oauth.mdx
+++ b/connection-guides/iam/meistertask-oauth.mdx
@@ -3,7 +3,6 @@ title: "MeisterTask - OAuth Authentication"
 description: "Follow these steps to connect MeisterTask via the StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure you are an Admin in your MeisterTask account.
@@ -65,7 +64,6 @@ If you've been directed to StackOne to integrate with MeisterTask, the following
   </Step>
 </Steps>
 
-<IntegrationFooter />
 
 
 ## Available data

--- a/connection-guides/iam/meistertask.mdx
+++ b/connection-guides/iam/meistertask.mdx
@@ -3,7 +3,6 @@ title: "MeisterTask - Access Token Authentication"
 description: "Follow these steps to connect MeisterTask via the StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure you are an Admin in your MeisterTask account.
@@ -58,7 +57,6 @@ If you've been directed to StackOne to integrate with MeisterTask, the following
   </Step>
 </Steps>
 
-<IntegrationFooter />
 
 
 ## Available data

--- a/connection-guides/iam/mixpanel.mdx
+++ b/connection-guides/iam/mixpanel.mdx
@@ -3,7 +3,6 @@ title: "Mixpanel"
 description: "Follow these steps to connect Mixpanel with StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure you have Owner or Admin privileges for your Mixpanel account.
@@ -79,7 +78,6 @@ If you've been directed to StackOne to integrate with Mixpanel, the following st
   </Step>
 </Steps>
 
-<IntegrationFooter />
 
 
 ## Available data

--- a/connection-guides/iam/netlify.mdx
+++ b/connection-guides/iam/netlify.mdx
@@ -3,7 +3,6 @@ title: "Netlify"
 description: "Follow these steps to connect Netlify via the StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure you have the Owner Role within Netlify.
@@ -75,7 +74,6 @@ If you've been directed to StackOne to integrate with Netlify, the following ste
   </Step>
 </Steps>
 
-<IntegrationFooter />
 
 
 ## Available data

--- a/connection-guides/iam/notion.mdx
+++ b/connection-guides/iam/notion.mdx
@@ -3,7 +3,6 @@ title: "Notion"
 description: "Follow these steps to connect Notion via the StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure that your Notion account has **Workspace owner** or **Workspace admin** privileges.
@@ -80,7 +79,6 @@ Proceed by clicking the Connect button.
     <img className='rounded-md' style={{ margin: '0 auto', border: '1px solid #efefef' }} alt="Enter Credentials" src="/images/notion/iam_image6.png" />
 </Frame>
 
-<IntegrationFooter />
 
 ## Available data
 

--- a/connection-guides/iam/okta.mdx
+++ b/connection-guides/iam/okta.mdx
@@ -3,7 +3,6 @@ title: "Okta"
 description: "Follow these steps to connect Okta via the StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure that your Okta account has **API Access Administrator**, **Organization Administrator**, or  **Super Administrator** privileges.
@@ -93,7 +92,6 @@ Proceed by clicking the Connect button.
     <img className='rounded-md' style={{ margin: '0 auto', border: '1px solid #efefef' }} alt="Enter Credentials" src="/images/okta/image9.png" />
 </Frame>
 
-<IntegrationFooter />
 
 ## Available data
 

--- a/connection-guides/iam/oneflow.mdx
+++ b/connection-guides/iam/oneflow.mdx
@@ -3,7 +3,6 @@ title: "Oneflow"
 description: "Follow these steps to connect Oneflow via the StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure that your Oneflow account has Administrator privileges.
@@ -65,7 +64,6 @@ If you've been directed to StackOne to integrate with Oneflow, the following ste
   </Step>
 </Steps>
 
-<IntegrationFooter />
 
 ## Available data
 

--- a/connection-guides/iam/onelogin.mdx
+++ b/connection-guides/iam/onelogin.mdx
@@ -3,7 +3,6 @@ title: "OneLogin"
 description: "Follow these steps to connect OneLogin via the StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure you have Admin privileges within your OneLogin account.
@@ -79,7 +78,6 @@ This guidance assumes that you are an Account Owner or Administrator in OneLogin
   </Step>
 </Steps>
 
-<IntegrationFooter />
 
 
 ## Available data

--- a/connection-guides/iam/openai.mdx
+++ b/connection-guides/iam/openai.mdx
@@ -3,7 +3,6 @@ title: "OpenAI"
 description: "Follow these steps to connect OpenAI via the StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure you have Owner privileges within your OpenAI organization.
@@ -75,7 +74,6 @@ If you've been directed to StackOne to integrate with OpenAI, the following step
   </Step>
 </Steps>
 
-<IntegrationFooter />
 
 
 ## Available data

--- a/connection-guides/iam/openvpn.mdx
+++ b/connection-guides/iam/openvpn.mdx
@@ -3,7 +3,6 @@ title: "OpenVPN"
 description: "Follow these steps to connect OpenVPN via the StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure that your OpenVPN account has Administrator privileges.
@@ -87,7 +86,6 @@ This can also be found in the URL once logged in.
   </Step>
 </Steps>
 
-<IntegrationFooter />
 
 ## Available data
 

--- a/connection-guides/iam/oraclehcm.mdx
+++ b/connection-guides/iam/oraclehcm.mdx
@@ -3,7 +3,6 @@ title: "Oracle HCM"
 description: "Follow these steps to connect Oracle HCM with StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure you have Admin privileges for your Oracle HCM account.
@@ -99,7 +98,6 @@ You can find the REST Server URL, username, and password in the welcome email se
   </Step>
 </Steps>
 
-<IntegrationFooter />
 
 
 ## Available data

--- a/connection-guides/iam/pinpoint.mdx
+++ b/connection-guides/iam/pinpoint.mdx
@@ -3,7 +3,6 @@ title: "Pinpoint"
 description: "Follow these steps to connect Pinpoint with StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure you have Admin privileges for your Pinpoint account.
@@ -101,7 +100,6 @@ In this example, the value would be: stackone
   </Step>
 </Steps>
 
-<IntegrationFooter />
 
 
 ## Available data

--- a/connection-guides/iam/pipedrive-oauth.mdx
+++ b/connection-guides/iam/pipedrive-oauth.mdx
@@ -3,7 +3,6 @@ title: "Pipedrive - OAuth Authentication"
 description: "Follow these steps to connect Pipedrive via the StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure you have Admin privileges for your Pipedrive account.
@@ -97,7 +96,6 @@ If you've been directed to StackOne to integrate with Pipedrive, the following s
   </Step>
 </Steps>
 
-<IntegrationFooter />
 
 
 ## Available data

--- a/connection-guides/iam/pipedrive.mdx
+++ b/connection-guides/iam/pipedrive.mdx
@@ -3,7 +3,6 @@ title: "Pipedrive"
 description: "Follow these steps to connect Pipedrive with StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure you have Admin privileges for your Pipedrive account.
@@ -53,7 +52,6 @@ Congratulations! You are now ready to connect with StackOne.
   </Step>
 </Steps>
 
-<IntegrationFooter />
 
 
 ## Available data

--- a/connection-guides/iam/qlik-oauth.mdx
+++ b/connection-guides/iam/qlik-oauth.mdx
@@ -3,7 +3,6 @@ title: "Qlik - OAuth Authentication"
 description: "Follow these steps to connect Qlik via the StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure you have Admin privileges within your Qlik Cloud.
@@ -102,7 +101,6 @@ If you've been directed to StackOne to integrate with Qlik, the following steps 
   </Step>
 </Steps>
 
-<IntegrationFooter />
 
 
 ## Available data

--- a/connection-guides/iam/qlik.mdx
+++ b/connection-guides/iam/qlik.mdx
@@ -3,7 +3,6 @@ title: "Qlik - API Key Authentication"
 description: "Follow these steps to connect Qlik via the StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure you have Admin privileges within your Qlik Cloud.
@@ -69,7 +68,6 @@ If you've been directed to StackOne to integrate with Qlik, the following steps 
   </Step>
 </Steps>
 
-<IntegrationFooter />
 
 
 ## Available data

--- a/connection-guides/iam/recruitee.mdx
+++ b/connection-guides/iam/recruitee.mdx
@@ -3,7 +3,6 @@ title: "Recruitee"
 description: "Follow these steps to connect Recruitee with StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure you have Admin privileges for your Recruitee account.
@@ -51,7 +50,6 @@ If you've been directed to StackOne to integrate with Recruitee, the following s
   </Step>
 </Steps>
 
-<IntegrationFooter />
 
 
 ## Available data

--- a/connection-guides/iam/render.mdx
+++ b/connection-guides/iam/render.mdx
@@ -3,7 +3,6 @@ title: "Render"
 description: "Follow these steps to connect Render via the StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure you have Admin privileges for your Render account.
@@ -33,7 +32,6 @@ Use the email address and password of the team admin account when connecting to 
   <img className='rounded-md' style={{ margin: '0 auto', border: '1px solid #efefef' }} alt="Admin credentials" src="/images/render/image4.png" />
 </Frame>
 
-<IntegrationFooter />
 
 
 ## Available data

--- a/connection-guides/iam/retool.mdx
+++ b/connection-guides/iam/retool.mdx
@@ -3,7 +3,6 @@ title: "Retool"
 description: "Follow these steps to connect Retool via the StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure that your Retool account has Admin privileges.
@@ -95,7 +94,6 @@ It will be in the following format: `https://your-subdomain.retool.com`
     </Frame>
 
 
-<IntegrationFooter />
 
 ## Available data
 

--- a/connection-guides/iam/ringcentral.mdx
+++ b/connection-guides/iam/ringcentral.mdx
@@ -3,7 +3,6 @@ title: "Ringcentral - OAuth Authentication"
 description: "Follow these steps to connect Ringcentral via the StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure that you have registered an account on [RingCentral Developers](https://developers.ringcentral.com/my-account.html) with Developer Admin privileges.
@@ -120,7 +119,6 @@ This connection will authenticate on behalf of a registered Application in RingC
   </Step>
 </Steps>
 
-<IntegrationFooter />
 
 ## Available data
 

--- a/connection-guides/iam/rollbar.mdx
+++ b/connection-guides/iam/rollbar.mdx
@@ -3,7 +3,6 @@ title: "Rollbar"
 description: "Follow these steps to connect Rollbar via the StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure you have Owner privileges within your Rollbar account.
@@ -56,7 +55,6 @@ Upon reaching the Link Account page, enter the **Account Access Token** from the
   <img className='rounded-md' style={{ margin: '0 auto', border: '1px solid #efefef' }} alt="Link Account" src="/images/rollbar/image6.png" />
 </Frame>
 
-<IntegrationFooter />
 
 
 ## Available data

--- a/connection-guides/iam/salesloft.mdx
+++ b/connection-guides/iam/salesloft.mdx
@@ -3,7 +3,6 @@ title: "Salesloft"
 description: "Follow these steps to connect Salesloft via the StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure you have Admin privileges for your Salesloft account.
@@ -57,7 +56,6 @@ This guidance assumes that you are an Admin within Salesloft.
   </Step>
 </Steps>
 
-<IntegrationFooter />
 
 
 ## Available data

--- a/connection-guides/iam/scaleway.mdx
+++ b/connection-guides/iam/scaleway.mdx
@@ -3,7 +3,6 @@ title: "Scaleway"
 description: "Follow these steps to connect Scaleway via the StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure your Scaleway Role has the Access to Organization features Rule assigned. Scaleway Policies and Rules for your organization can be viewed on the [Identity and Access Management (IAM) > Policies](https://console.scaleway.com/iam/policies) page.
@@ -161,7 +160,6 @@ If you've been directed to StackOne to integrate with Scaleway, the following st
   </Step>
 </Steps>
 
-<IntegrationFooter />
 
 
 ## Available data

--- a/connection-guides/iam/scoro.mdx
+++ b/connection-guides/iam/scoro.mdx
@@ -3,7 +3,6 @@ title: "Scoro"
 description: "Follow these steps to connect Scoro via the StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure you are an Administrator in your Scoro account.
@@ -99,7 +98,6 @@ Given the URL: `https://my-company.scoro.com/settings`, your **Company Account I
   </Step>
 </Steps>
  
-<IntegrationFooter />
 
 
 ## Available data

--- a/connection-guides/iam/sendgrid.mdx
+++ b/connection-guides/iam/sendgrid.mdx
@@ -3,7 +3,6 @@ title: "Sendgrid"
 description: "Follow these steps to connect Sendgrid with StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure you have Owner privileges for your Sendgrid account.
@@ -72,7 +71,6 @@ Upon reaching the Link Account page, enter the generated API key and proceed by 
   />
 </Frame>
 
-<IntegrationFooter />
 
 
 ## Available data

--- a/connection-guides/iam/smartrecruiters.mdx
+++ b/connection-guides/iam/smartrecruiters.mdx
@@ -3,7 +3,6 @@ title: "SmartRecruiters"
 description: "Follow these steps to connect SmartRecruiters with StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure you have Admin privileges for your SmartRecruiters account.
@@ -83,7 +82,6 @@ If you've been directed to StackOne to integrate with SmartRecruiters, the follo
   </Step>
 </Steps>
 
-<IntegrationFooter />
 
 
 ## Available data

--- a/connection-guides/iam/smartsheet-oauth.mdx
+++ b/connection-guides/iam/smartsheet-oauth.mdx
@@ -3,7 +3,6 @@ title: "Smartsheet (OAuth)"
 description: "Follow these steps to connect Smartsheet via the StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure that your Smartsheet account has Administrator privileges.
@@ -84,7 +83,6 @@ Upon reaching the Link Account page, enter the credentials from the previous ste
 
 Proceed by clicking the Connect button.
 
-<IntegrationFooter />
 
 ## Available data
 

--- a/connection-guides/iam/smartsheet.mdx
+++ b/connection-guides/iam/smartsheet.mdx
@@ -3,7 +3,6 @@ title: "Smartsheet"
 description: "Follow these steps to connect Smartsheet via the StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure that your Smartsheet account has Administrator privileges.
@@ -78,7 +77,6 @@ Log in to your Smartsheet account at https://app.smartsheet.com
   </Step>
 </Steps>
 
-<IntegrationFooter />
 
 ## Available data
 

--- a/connection-guides/iam/sonarcloud.mdx
+++ b/connection-guides/iam/sonarcloud.mdx
@@ -3,7 +3,6 @@ title: "SonarCloud"
 description: "Follow these steps to connect SonarCloud via the StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure you have Admins privileges within your SonarCloud account.
@@ -71,7 +70,6 @@ If you've been directed to StackOne to integrate with SonarCloud, the following 
   </Step>
 </Steps>
 
-<IntegrationFooter />
 
 
 ## Available data

--- a/connection-guides/iam/sophos.mdx
+++ b/connection-guides/iam/sophos.mdx
@@ -3,7 +3,6 @@ title: "Sophos"
 description: "Follow these steps to connect Sophos via the StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure that your Sophos account has Administrator privileges.
@@ -104,7 +103,6 @@ Upon reaching the Link Account page, enter the credentials from the previous ste
 Proceed by clicking the Connect button.
 
 
-<IntegrationFooter />
 
 ## Available data
 

--- a/connection-guides/iam/spendesk.mdx
+++ b/connection-guides/iam/spendesk.mdx
@@ -3,7 +3,6 @@ title: "Spendesk"
 description: "Follow these steps to connect Spendesk via the StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure you have Account Owner privileges within your Spendesk account.
@@ -43,7 +42,6 @@ If you've been directed to StackOne to integrate with Spendesk, the following st
   </Step>
 </Steps>
 
-<IntegrationFooter />
 
 
 ## Available data

--- a/connection-guides/iam/spotdraft.mdx
+++ b/connection-guides/iam/spotdraft.mdx
@@ -3,7 +3,6 @@ title: "Spotdraft"
 description: "Follow these steps to connect Spotdraft with StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure you have Admin privileges for your Spotdraft account.
@@ -69,7 +68,6 @@ You will need to provide a user email and password. It is recommended that you s
   </Step>
 </Steps>
 
-<IntegrationFooter />
 
 
 ## Available data

--- a/connection-guides/iam/tableau.mdx
+++ b/connection-guides/iam/tableau.mdx
@@ -3,7 +3,6 @@ title: "Tableau"
 description: "Follow these steps to connect Tableau via the StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure you have Site Administrator Creator privileges for your Tableau account.
@@ -70,7 +69,6 @@ If you've been directed to StackOne to integrate with Tableau, the following ste
   </Step>
 </Steps>
 
-<IntegrationFooter />
 
 
 ## Available data

--- a/connection-guides/iam/talentlms.mdx
+++ b/connection-guides/iam/talentlms.mdx
@@ -3,7 +3,6 @@ title: "TalentLMS - IAM"
 description: "Follow these steps to connect TalentLMS via the StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure you are a SuperAdmin or Account Owner in your TalentLMS account.
@@ -64,7 +63,6 @@ If you've been directed to StackOne to integrate with TalentLMS, the following s
   </Step>
 </Steps>
 
-<IntegrationFooter />
 
 
 ## Available data

--- a/connection-guides/iam/teamtailor.mdx
+++ b/connection-guides/iam/teamtailor.mdx
@@ -3,7 +3,6 @@ title: "Teamtailor"
 description: "Follow these steps to connect Teamtailor with StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure you have Admin privileges for your Teamtailor account.
@@ -149,7 +148,6 @@ Follow steps 2.1 to 2.2 inclusive to create the employee, you will then have to 
   </Step>
 </Steps>
 
-<IntegrationFooter />
 
 
 ## Available data

--- a/connection-guides/iam/teamviewer-oauth.mdx
+++ b/connection-guides/iam/teamviewer-oauth.mdx
@@ -3,7 +3,6 @@ title: "Teamviewer (OAuth)"
 description: "Follow these steps to connect Teamviewer via the StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure that your Teamviewer account has Admin privileges.
@@ -83,7 +82,6 @@ Upon reaching the Link Account page, enter the credentials from the previous ste
 Proceed by clicking the Connect button.
 
 
-<IntegrationFooter />
 
 ## Available data
 

--- a/connection-guides/iam/teamviewer.mdx
+++ b/connection-guides/iam/teamviewer.mdx
@@ -3,7 +3,6 @@ title: "Teamviewer"
 description: "Follow these steps to connect Teamviewer via the StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure that your Teamviewer account has Admin privileges.
@@ -74,7 +73,6 @@ Upon reaching the Link Account page, enter your **Script Token** created in the 
 
 Proceed by clicking the Connect button.
 
-<IntegrationFooter />
 
 ## Available data
 

--- a/connection-guides/iam/teamwork.mdx
+++ b/connection-guides/iam/teamwork.mdx
@@ -3,7 +3,6 @@ title: "Teamwork"
 description: "Follow these steps to connect Teamwork via the StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure you are a Site Owner within your Teamwork account.
@@ -68,7 +67,6 @@ If you've been directed to StackOne to integrate with Teamwork, the following st
   </Step>
 </Steps>
 
-<IntegrationFooter />
 
 
 ## Available data

--- a/connection-guides/iam/terraform.mdx
+++ b/connection-guides/iam/terraform.mdx
@@ -3,7 +3,6 @@ title: "Terraform"
 description: "Follow these steps to connect Terraform via the StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure you have Admin or Owner privileges within your Terraform account.
@@ -83,7 +82,6 @@ If you've been directed to StackOne to integrate with Terraform, the following s
   </Step>
 </Steps>
 
-<IntegrationFooter />
 
 
 ## Available data

--- a/connection-guides/iam/toggl.mdx
+++ b/connection-guides/iam/toggl.mdx
@@ -3,7 +3,6 @@ title: "Toggl"
 description: "Follow these steps to connect Toggl via the StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure you have Admin privileges within your Toggl account.
@@ -61,7 +60,6 @@ This guidance assumes that you are an Organization Admin within Toggl.
   </Step>
 </Steps>
 
-<IntegrationFooter />
 
 
 ## Available data

--- a/connection-guides/iam/twilio.mdx
+++ b/connection-guides/iam/twilio.mdx
@@ -3,7 +3,6 @@ title: "Twilio"
 description: "Follow these steps to connect Twilio via the StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Twilio's underlying Organizations API is currently in private beta. To enable this feature, reach out to your Twilio account executive or [Twilio Support](https://help.twilio.com/articles/360048500694#h_01HTDZ3N3VFM4QXHRZR5MSFS6A). 
@@ -109,7 +108,6 @@ If you've been directed to StackOne to integrate with Twilio, the following step
   </Step>
 </Steps>
 
-<IntegrationFooter />
 
 ## Available data
 

--- a/connection-guides/iam/webex.mdx
+++ b/connection-guides/iam/webex.mdx
@@ -3,7 +3,6 @@ title: "Webex"
 description: "Follow these steps to connect Webex via the StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure you have Full Admin privileges for your Webex account.
@@ -103,7 +102,6 @@ The Client ID and Client Secret required for the StackOne connection will be pro
   </Step>
 </Steps>
 
-<IntegrationFooter />
 
 
 ## Available data

--- a/connection-guides/iam/webflow-oauth.mdx
+++ b/connection-guides/iam/webflow-oauth.mdx
@@ -3,7 +3,6 @@ title: "Webflow (Site)"
 description: "Follow these steps to connect Webflow via the StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure that the authenticating Webflow account has Admin privileges within the Webflow site to be connected.
@@ -138,7 +137,6 @@ This connection will authenticate on behalf of a registered Application in Webfl
   </Step>
 </Steps>
 
-<IntegrationFooter />
 
 ## Available data
 

--- a/connection-guides/iam/webflowworkspace.mdx
+++ b/connection-guides/iam/webflowworkspace.mdx
@@ -3,7 +3,6 @@ title: "Webflow (Workspace)"
 description: "Follow these steps to connect Webflow via the StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure that the authenticating Webflow account has Admin or Owner privileges within the Webflow Workspace to be connected.
@@ -70,7 +69,6 @@ Proceed by clicking the Connect button.
     <img className='rounded-md' style={{ margin: '0 auto', border: '1px solid #efefef' }} alt="Enter Credentials" src="/images/webflowworkspace/image3.png" />
 </Frame>
 
-<IntegrationFooter />
 
 ## Available data
 

--- a/connection-guides/iam/workable.mdx
+++ b/connection-guides/iam/workable.mdx
@@ -3,7 +3,6 @@ title: "Workable"
 description: "If you've been directed to StackOne to integrate with Workable, the following steps will help you understand the process and any necessary actions to configure successful integration."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   This guidance assumes you have Super Admin privileges for your Workable account.
@@ -66,7 +65,6 @@ In StackOne, ensure the Workable integration is enabled. In <b>Accounts > Link A
   <img className='rounded-md' style={{ margin: '0 auto', border: '1px solid #efefef' }} alt="Connect Workable" src="/images/workable/image5.png" />
 </Frame>
 
-<IntegrationFooter />
 
 
 ## Available data

--- a/connection-guides/iam/zelt.mdx
+++ b/connection-guides/iam/zelt.mdx
@@ -3,7 +3,6 @@ title: "Zelt"
 description: "Follow these steps to connect Zelt with StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure you have Admin privileges for your Zelt account.
@@ -73,7 +72,6 @@ If you've been directed to StackOne to integrate with Zelt, the following steps 
   </Step>
 </Steps>
 
-<IntegrationFooter />
 
 
 ## Available data

--- a/connection-guides/lms/360learning.mdx
+++ b/connection-guides/lms/360learning.mdx
@@ -3,7 +3,6 @@ title: "360 Learning"
 description: "If you've been directed to StackOne to integrate with 360 Learning, the following steps will help you understand the process and any necessary actions to configure successful integration."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   This guidance assumes you have Admin privileges for your 360 Learning account.
@@ -85,7 +84,6 @@ You can use the Company ID and API Key to link your 360 Learning account.
 
   </Steps>
 
-<IntegrationFooter />
 
 ## Useful Links
 <Card title="API Reference" icon="link" href="https://api.360learning.com/">

--- a/connection-guides/lms/bamboohr.mdx
+++ b/connection-guides/lms/bamboohr.mdx
@@ -3,7 +3,6 @@ title: "BambooHR"
 description: "Follow these steps to connect BambooHR via the StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure you have Admin privileges for your BambooHR account.
@@ -85,7 +84,6 @@ Now that you have all the required information, you can link your account.
   </Step>
 </Steps>
 
-<IntegrationFooter />
 
 ## Available data
 

--- a/connection-guides/lms/brainier.mdx
+++ b/connection-guides/lms/brainier.mdx
@@ -3,7 +3,6 @@ title: Brainier
 description: Follow these steps to connect Brainier via the StackOne Hub successfully.
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 ## Overview
 
@@ -149,4 +148,3 @@ If you encounter issues during the integration process, check the following:
 >
   Access Brainier's official API documentation for detailed information about available endpoints and methods.
 </Card>
-<IntegrationFooter />

--- a/connection-guides/lms/cornerstone.mdx
+++ b/connection-guides/lms/cornerstone.mdx
@@ -3,7 +3,6 @@ title: "Cornerstone"
 description: "Follow these steps to connect Cornerstone via the StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure that your Cornerstone account has Admin privileges.
@@ -100,7 +99,6 @@ If you've been directed to StackOne to integrate with Cornerstone, the following
   </Step>
 </Steps>
 
-<IntegrationFooter />
 
 ## Troubleshooting
 

--- a/connection-guides/lms/cornerstone_library.mdx
+++ b/connection-guides/lms/cornerstone_library.mdx
@@ -3,7 +3,6 @@ title: "Cornerstone Library"
 description: "Follow these steps to connect Cornerstone Library via the StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Note>
   This guide is for Cornerstone Library. In this case the account represents the connection with Cornerstone since this single account will push content to be distributed by Cornerstone to multiple tenants.
@@ -20,4 +19,3 @@ import IntegrationFooter from "/snippets/integration-footer.mdx";
   </Step>
 </Steps>
 
-<IntegrationFooter />

--- a/connection-guides/lms/cornerstone_library_single_tenant.mdx
+++ b/connection-guides/lms/cornerstone_library_single_tenant.mdx
@@ -3,7 +3,6 @@ title: "Cornerstone Library (Single Tenant)"
 description: "Follow these steps to connect Cornerstone Library (Single Tenant) via the StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 ## Linking your Account
 
@@ -16,4 +15,3 @@ import IntegrationFooter from "/snippets/integration-footer.mdx";
   </Step>
 </Steps>
 
-<IntegrationFooter />

--- a/connection-guides/lms/coursera.mdx
+++ b/connection-guides/lms/coursera.mdx
@@ -3,7 +3,6 @@ title: "Coursera"
 description: "If you've been directed to StackOne to integrate with Coursera, the following steps will help you understand the process and any necessary actions to configure successful integration."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure you have Admin privileges for your Coursera account.
@@ -66,7 +65,6 @@ import IntegrationFooter from "/snippets/integration-footer.mdx";
   </Step>
 </Steps>
 
-<IntegrationFooter />
 
 ## Useful Links
 <Card title="Coursera Developer Portal" icon="link" href="https://dev.coursera.com">

--- a/connection-guides/lms/go1_library.mdx
+++ b/connection-guides/lms/go1_library.mdx
@@ -3,7 +3,6 @@ title: "GO1 Library"
 description: "Follow these steps to connect GO1 Library via the StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Note>
   This guide is for GO1 Library. In this case the account represents the connection with GO1 since this single account will push content to be distributed by GO1 to multiple tenants.
@@ -27,4 +26,3 @@ import IntegrationFooter from "/snippets/integration-footer.mdx";
   </Step>
 </Steps>
 
-<IntegrationFooter />

--- a/connection-guides/lms/infosec.mdx
+++ b/connection-guides/lms/infosec.mdx
@@ -2,7 +2,6 @@
 title: "Infosec IQ"
 description: "How to obtain the credentials required to connect to Infosec IQ."
 ---
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
 You must have administrator access in your Infosec IQ account to complete these steps.
@@ -49,4 +48,3 @@ You must have administrator access in your Infosec IQ account to complete these 
   </Step>
 </Steps>
 
-<IntegrationFooter />

--- a/connection-guides/lms/peoplefluent.mdx
+++ b/connection-guides/lms/peoplefluent.mdx
@@ -2,7 +2,6 @@
 title: "PeopleFluent"
 description: "How to obtain the credentials required to connect to PeopleFluent."
 ---
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
 You must have administrator access in your PeopleFluent account to complete these steps.
@@ -45,4 +44,3 @@ You must have administrator access in your PeopleFluent account to complete thes
   </Step>
 </Steps>
 
-<IntegrationFooter />

--- a/connection-guides/lms/sapsuccessfactors.mdx
+++ b/connection-guides/lms/sapsuccessfactors.mdx
@@ -3,7 +3,6 @@ title: "SAP SuccessFactors"
 description: "Follow these steps to connect SAP SuccessFactors with StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure you have Admin privileges for your SAP SuccessFactors account.
@@ -699,7 +698,6 @@ Note: The integration may take up to 15 minutes to initially authenticate once t
   </Step>
 </Steps>
 
-<IntegrationFooter />
 
 ### Useful Links
 <Card title="API Reference" icon="link" href="https://api.sap.com/products/SAPSuccessFactors/apis/all">

--- a/connection-guides/lms/talentlms.mdx
+++ b/connection-guides/lms/talentlms.mdx
@@ -3,7 +3,6 @@ title: "TalentLMS"
 description: "Follow these steps to connect TalentLMS via the StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure you are a SuperAdmin or Account Owner in your TalentLMS account.
@@ -64,7 +63,6 @@ If you've been directed to StackOne to integrate with TalentLMS, the following s
   </Step>
 </Steps>
 
-<IntegrationFooter />
 
 ## Useful Links
 <Card title="API Reference" icon="link" href="https://market.talentlms.com/pages/docs/TalentLMS-API-Documentation.pdf">

--- a/connection-guides/lms/workdaylearning.mdx
+++ b/connection-guides/lms/workdaylearning.mdx
@@ -3,7 +3,6 @@ title: "Workday Learning"
 description: "If you've been directed to StackOne to integrate with Workday, the following steps will help you understand the process and any necessary actions to configure successful integration."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   This guidance assumes you have Admin privileges for your Workday account.
@@ -291,7 +290,6 @@ import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 </Steps>
 
-<IntegrationFooter />
 
 <Card title="Useful Links" icon="link" href="https://doc.workday.com">
   Workday API reference: <a href="https://doc.workday.com">https://doc.workday.com</a>

--- a/connection-guides/lms/workdaylearning_oauth.mdx
+++ b/connection-guides/lms/workdaylearning_oauth.mdx
@@ -3,7 +3,6 @@ title: "Workday Learning (REST API)"
 description: "If you've been directed to StackOne to integrate with Workday Learning (REST API), the following steps will help you understand the process and any necessary actions to configure successful integration."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   This guidance assumes you have Admin privileges for your Workday account.
@@ -88,7 +87,6 @@ You can use the **Client ID**, **Client Secret** and **Refresh Token** credentia
   <img className='rounded-md' style={{ margin: '0 auto', border: '1px solid #efefef' }} alt="Link to StackOne" src="/images/workday/wql-connect-account.png" />
 </Frame>
 
-<IntegrationFooter />
 
 <Card title="Useful Links" icon="link" href="https://doc.workday.com">
     https://doc.workday.com

--- a/connection-guides/lms/xyleme.mdx
+++ b/connection-guides/lms/xyleme.mdx
@@ -3,7 +3,6 @@ title: "Xyleme"
 description: "If you've been directed to StackOne to integrate with Xyleme, the following steps will help you understand the process and any necessary actions to configure successful integration."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   This guidance assumes you have Admin privileges for your Xyleme account.
@@ -72,7 +71,6 @@ Use your domain and system account credentials to connect Xyleme with StackOne.
   </Step>
 </Steps>
 
-<IntegrationFooter />
 
 ## Useful Links
 

--- a/connection-guides/marketing/airship.mdx
+++ b/connection-guides/marketing/airship.mdx
@@ -3,7 +3,6 @@ title: "Airship"
 description: "Follow these steps to connect Airship with StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure you have Admin privileges for your Airship account.
@@ -82,4 +81,3 @@ If you've been directed to StackOne to integrate with Airship, the following ste
   </Step>
 </Steps>
 
-<IntegrationFooter />

--- a/connection-guides/marketing/braze.mdx
+++ b/connection-guides/marketing/braze.mdx
@@ -3,7 +3,6 @@ title: "Braze"
 description: "Follow these steps to connect Braze with StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure you have Admin privileges for your Braze account.
@@ -107,7 +106,6 @@ If you've been directed to StackOne to integrate with Braze, the following steps
   </Step>
 </Steps>
 
-<IntegrationFooter />
 
 ## Useful Links
 

--- a/connection-guides/marketing/klaviyo.mdx
+++ b/connection-guides/marketing/klaviyo.mdx
@@ -3,7 +3,6 @@ title: "Klaviyo"
 description: "Follow these steps to connect Klaviyo via the StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure you have a paid Klaviyo plan and that you are an Admin or Owner in your Klaviyo account.
@@ -71,4 +70,3 @@ If you've been directed to StackOne to integrate with Klaviyo, the following ste
   </Step>
 </Steps>
 
-<IntegrationFooter />

--- a/connection-guides/marketing/moengage.mdx
+++ b/connection-guides/marketing/moengage.mdx
@@ -3,7 +3,6 @@ title: "MoEngage"
 description: "Follow these steps to connect MoEngage via the StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure that your MoEngage account has Admin privileges.
@@ -70,7 +69,6 @@ If you've been directed to StackOne to integrate with MoEngage, the following st
   </Step>
 </Steps>
 
-<IntegrationFooter />
 
 ## Available data
 

--- a/connection-guides/marketing/sfmc.mdx
+++ b/connection-guides/marketing/sfmc.mdx
@@ -3,7 +3,6 @@ title: "Salesforce Marketing Cloud"
 description: "Follow these steps to connect Salesforce Marketing Cloud via the StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure you have `Installed Package | Administer` permission. This permission is automatically applied to the Administrator and Marketing Cloud Administrator system-defined roles. Add the permission for a different role or user in the Administration area.
@@ -95,4 +94,3 @@ If you've been directed to StackOne to integrate with Salesforce Marketing Cloud
   </Step>
 </Steps>
 
-<IntegrationFooter />

--- a/connection-guides/screening/veremark.mdx
+++ b/connection-guides/screening/veremark.mdx
@@ -3,7 +3,6 @@ title: "Veremark"
 description: "Follow these steps to connect Veremark with StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure you have Admin privileges for your Veremark account.
@@ -30,7 +29,6 @@ If you've been directed to StackOne to integrate with Veremark, the following st
   </Step>
 </Steps>
 
-<IntegrationFooter />
 
 ## Useful Links
 <Card title="API Reference" icon="link" href="https://api.veremark.com/external/v1/docs/">

--- a/connection-guides/screening/zinc.mdx
+++ b/connection-guides/screening/zinc.mdx
@@ -3,7 +3,6 @@ title: "Zinc"
 description: "If you have been directed to StackOne to integrate with Zinc, the following steps will help you understand the process and any necessary actions to configure successful integration."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   The following guidance assumes you have Admin privileges for your Zinc
@@ -49,7 +48,6 @@ Upon reaching the Link Account page, enter the generated API key and proceed by 
   />
 </Frame>
 
-<IntegrationFooter />
 
 ## Useful Links
 <Card title="API Reference" icon="link" href="https://docs.zincwork.com/">

--- a/connection-guides/ticketing/asana-oauth.mdx
+++ b/connection-guides/ticketing/asana-oauth.mdx
@@ -3,7 +3,6 @@ title: "Asana - OAuth2"
 description: "Follow these steps to connect your Asana account with StackOne hub using OAuth2, ensuring a smooth integration process."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   The following guidance assumes you have Admin privileges for your Asana account.
@@ -89,7 +88,6 @@ Once you have entered this information, you can proceed with the integration pro
   </Step>
 </Steps>
 
-<IntegrationFooter />
 
 ## Useful Links
 <Card title="Asana Guides - OAuth" icon="link" href="https://developers.asana.com/docs/oauth">

--- a/connection-guides/ticketing/asana.mdx
+++ b/connection-guides/ticketing/asana.mdx
@@ -3,7 +3,6 @@ title: "Asana"
 description: "Follow these steps to connect your Asana account with StackOne hub, ensuring a smooth integration process."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   The following guidance assumes you have Admin privileges for your Asana
@@ -55,7 +54,6 @@ This will require the Personal Access Token you just generated and the workspace
   </Step>
 </Steps>
 
-<IntegrationFooter />
 
 ## Useful Links
 <Card title="Asana Guides - PAT" icon="link" href="https://developers.asana.com/docs/personal-access-token">

--- a/connection-guides/ticketing/hubspot.mdx
+++ b/connection-guides/ticketing/hubspot.mdx
@@ -3,7 +3,6 @@ title: "HubSpot"
 description: "Follow these steps to connect HubSpot with StackOne Hub successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   Ensure you have Admin privileges for your HubSpot account.
@@ -44,7 +43,6 @@ If you've been directed to StackOne to integrate with HubSpot, the following ste
   </Step>
 </Steps>
 
-<IntegrationFooter />
 
 <Card title="Useful Links" icon="link" href="https://developers.hubspot.com/docs/api/overview">
   HubSpot API documentation: https://developers.hubspot.com/docs/api/overview

--- a/connection-guides/ticketing/zendesk.mdx
+++ b/connection-guides/ticketing/zendesk.mdx
@@ -3,7 +3,6 @@ title: "Zendesk"
 description: "Follow these steps to connect your Zendesk account with StackOne hub, ensuring a smooth integration process."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   The following guidance assumes you have Admin privileges for your Zendesk
@@ -67,7 +66,6 @@ This will require Subdomain, email, and the API token you just generated.
   Ensure that the user has the necessary permissions to access the Zendesk resources required for the integration.
 </Warning>
 
-<IntegrationFooter />
 
 ## Useful Links
 <Card title="API Reference" icon="link" href="https://developer.zendesk.com/api-reference/">

--- a/integration-configuration-concepts/ats/ashby-background-check.mdx
+++ b/integration-configuration-concepts/ats/ashby-background-check.mdx
@@ -3,7 +3,6 @@ title: "Ashby Background Check"
 description: "To successfully send test notifications from Ashby, follow these steps in your Ashby account, and complete the necessary actions."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   The following guidance assumes you have Admin privileges for your Ashby
@@ -125,7 +124,6 @@ import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 
 
-<IntegrationFooter />
 
 ## Useful Links
 <Card title="API Reference" icon="link" href="https://developers.ashbyhq.com/reference/assessmentstart">

--- a/integration-configuration-concepts/ats/bullhorn-application-custom-field.mdx
+++ b/integration-configuration-concepts/ats/bullhorn-application-custom-field.mdx
@@ -3,7 +3,6 @@ title: "Bullhorn Application Custom Fields"
 description: "To create and view application custom fields in Bullhorn, follow these steps."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   This guide assumes that you have administrative privileges for your Bullhorn account.
@@ -125,7 +124,6 @@ import IntegrationFooter from "/snippets/integration-footer.mdx";
   </Step>
 </Steps>
 
-<IntegrationFooter />
 
 ## Useful Links
 <Card title="API Reference" icon="link" href="https://kb.bullhorn.com/ats/Content/BHATS/Topics/creatingCustomField.htm?Highlight=custom%20fields">

--- a/integration-configuration-concepts/ats/bullhorn-assessment-background-check.mdx
+++ b/integration-configuration-concepts/ats/bullhorn-assessment-background-check.mdx
@@ -3,7 +3,6 @@ title: "Bullhorn Assessment or Background Check"
 description: "To successfully send webhook notifications from Bullhorn, follow these steps in your Bullhorn account and complete the required actions."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 
 ## Send the assessment or background check invitation to the candidate
@@ -57,7 +56,6 @@ import IntegrationFooter from "/snippets/integration-footer.mdx";
 </Steps>
 
 
-<IntegrationFooter />
 
 
 ## Useful Links

--- a/integration-configuration-concepts/ats/bullhorn-job-custom-field.mdx
+++ b/integration-configuration-concepts/ats/bullhorn-job-custom-field.mdx
@@ -3,7 +3,6 @@ title: "Bullhorn Job Custom Fields"
 description: "To create and view job custom fields in Bullhorn, follow these steps."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   This guide assumes you have administrative privileges for your Bullhorn account.
@@ -112,7 +111,6 @@ import IntegrationFooter from "/snippets/integration-footer.mdx";
   </Step>
 </Steps>
 
-<IntegrationFooter />
 
 ## Useful Links
 <Card title="API Reference" icon="link" href="https://kb.bullhorn.com/ats/Content/BHATS/Topics/creatingCustomField.htm?Highlight=custom%20fields">

--- a/integration-configuration-concepts/ats/eploy-background-check.mdx
+++ b/integration-configuration-concepts/ats/eploy-background-check.mdx
@@ -3,7 +3,6 @@ title: "Eploy Background Check"
 description: "To successfully send webhook notifications from Eploy, follow these steps in your Eploy account, and complete the necessary actions."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   This guidance assumes that you have admin privileges for your Eploy account.
@@ -196,7 +195,6 @@ Go to the _Pipeline_ page and click on the candidate to view the updated result 
 
 
 
-<IntegrationFooter />
 
 ## Useful Links
 <Card title="API Reference" icon="link" href="https://support.eploy.co.uk/hc/en-gb/articles/14089926025757-Eploy-RESTful-API-Workflow-based-Integrations">

--- a/integration-configuration-concepts/ats/greenhouse-assessment-background-check.mdx
+++ b/integration-configuration-concepts/ats/greenhouse-assessment-background-check.mdx
@@ -3,7 +3,6 @@ title: "Greenhouse Assessment or Background Check"
 description: "To successfully send webhook notifications from Greenhouse, follow these steps in your Greenhouse account, and complete the necessary actions."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 
 ## Send the assessment or background check invitation to the candidate
@@ -98,7 +97,6 @@ import IntegrationFooter from "/snippets/integration-footer.mdx";
 </Steps>
 
 
-<IntegrationFooter />
 
 ## Useful Links
 <Card title="API Reference" icon="link" href="https://developers.greenhouse.io/assessment.html#introduction">

--- a/integration-configuration-concepts/ats/recruitee-assessment-background-checks.mdx
+++ b/integration-configuration-concepts/ats/recruitee-assessment-background-checks.mdx
@@ -3,7 +3,6 @@ title: "Recruitee Assessment or Background Check"
 description: "To successfully send test notifications from Recruitee, follow these steps in your Recruitee account and complete the necessary actions."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Note>
   This documentation proceeds with the `Assessments` configuration steps. However, the `Background Check` process follows the exact same steps as `Assessments`.
@@ -53,7 +52,6 @@ import IntegrationFooter from "/snippets/integration-footer.mdx";
 </Steps>
 
 
-<IntegrationFooter />
 
 ## Useful Links
 <Card title="API Reference" icon="link" href="https://docs.recruitee.com/reference/post-partner">

--- a/integration-configuration-concepts/ats/sapsuccessfactors-application-custom-fields.mdx
+++ b/integration-configuration-concepts/ats/sapsuccessfactors-application-custom-fields.mdx
@@ -3,7 +3,6 @@ title: "SAP SuccessFactors Application Custom Fields"
 description: "To create and view application custom fields in SAP SuccessFactors, follow these steps"
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   This guidance assumes that you have admin privileges for your SAP SuccessFactors account.
@@ -202,4 +201,3 @@ import IntegrationFooter from "/snippets/integration-footer.mdx";
   </Step>
 </Steps>
 
-<IntegrationFooter />

--- a/integration-configuration-concepts/ats/sapsuccessfactors-assessment.mdx
+++ b/integration-configuration-concepts/ats/sapsuccessfactors-assessment.mdx
@@ -3,7 +3,6 @@ title: "SAP SuccessFactors Assessment"
 description: "To send webhook notifications successfully from SAP SuccessFactors, follow these steps in your SAP SuccessFactors account and complete the required actions."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 
 ## Associate assessment to the job requisition
@@ -69,7 +68,6 @@ import IntegrationFooter from "/snippets/integration-footer.mdx";
   </Step>
 </Steps>
 
-<IntegrationFooter />
 
 ## Useful Links
 <Card title="API Reference" icon="link" href="https://api.sap.com/products/SAPSuccessFactors/apis/all">

--- a/integration-configuration-concepts/ats/sapsuccessfactors-background-check.mdx
+++ b/integration-configuration-concepts/ats/sapsuccessfactors-background-check.mdx
@@ -3,7 +3,6 @@ title: "SAP SuccessFactors Background Check"
 description: "To successfully send webhook notifications from SAP SuccessFactors, follow these steps in your SAP SuccessFactors account and complete the necessary actions."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 
 ## Associate background check to the Job Requisition
@@ -66,7 +65,6 @@ import IntegrationFooter from "/snippets/integration-footer.mdx";
   </Step>
 </Steps>
 
-<IntegrationFooter />
 
 
 ## Useful Links

--- a/integration-configuration-concepts/ats/sapsuccessfactors-job-custom-field.mdx
+++ b/integration-configuration-concepts/ats/sapsuccessfactors-job-custom-field.mdx
@@ -3,7 +3,6 @@ title: "SAP SuccessFactors Job Custom Field"
 description: "To create and view job custom field in SAP SuccessFactors, follow these steps"
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   This guidance assumes that you have admin privileges for your SAP SuccessFactors account.
@@ -124,4 +123,3 @@ import IntegrationFooter from "/snippets/integration-footer.mdx";
   </Step>
 </Steps>
 
-<IntegrationFooter />

--- a/integration-configuration-concepts/ats/sapsuccessfactors-template-configuration-for-create-offer.mdx
+++ b/integration-configuration-concepts/ats/sapsuccessfactors-template-configuration-for-create-offer.mdx
@@ -3,7 +3,6 @@ title: "SAP SuccessFactors Offer Template Configuration for Offer Creation"
 description: "To configure Offer Template in SAP SuccessFactors, follow these steps"
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   This guidance assumes that you have admin privileges for your SAP SuccessFactors account.

--- a/integration-configuration-concepts/ats/sapsuccessfactors_job_visibility_on_UI.mdx
+++ b/integration-configuration-concepts/ats/sapsuccessfactors_job_visibility_on_UI.mdx
@@ -3,7 +3,6 @@ title: "SAP SuccessFactors Job visibility on UI"
 description: "To make hidden jobs visible in SAP SuccessFactors, follow these steps"
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   This guidance assumes that you have admin privileges for your SAP SuccessFactors account.

--- a/integration-configuration-concepts/ats/smartrecruiters-assessment-background-check.mdx
+++ b/integration-configuration-concepts/ats/smartrecruiters-assessment-background-check.mdx
@@ -3,7 +3,6 @@ title: "SmartRecruiters Background Check"
 description: "To successfully send background check or assessment notifications from SmartRecruiters, follow these steps in your SmartRecruiters account and complete the required actions."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   The following guidance assumes you have Admin privileges for your SmartRecruiters
@@ -286,7 +285,6 @@ Navigate to the candidate application to check the status of assessment orders o
   </Step>
 </Steps>
 
-<IntegrationFooter />
 
 ## Useful Links
 <Card title="API Reference" icon="link" href="https://developers.smartrecruiters.com/reference/apply-api">

--- a/integration-configuration-concepts/ats/teamtailor-assessment-or-background-check.mdx
+++ b/integration-configuration-concepts/ats/teamtailor-assessment-or-background-check.mdx
@@ -3,7 +3,6 @@ title: "Teamtailor Assessment or Background Check"
 description: "To connect Teamtailor Marketplace Integration with StackOne and send webhook notifications from Teamtailor, follow these steps in your Teamtailor account, and complete the necessary actions."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 
 ## Activate Marketplace Integration from Teamtailor
@@ -83,7 +82,6 @@ import IntegrationFooter from "/snippets/integration-footer.mdx";
 </Steps>
 
 
-<IntegrationFooter />
 
 ## Useful Links
 <Card title="API Reference" icon="link" href="https://doc.teamtailor.com/">

--- a/integration-configuration-concepts/ats/workable-application-custom-field.mdx
+++ b/integration-configuration-concepts/ats/workable-application-custom-field.mdx
@@ -3,7 +3,6 @@ title: "Workable Application Custom Fields"
 description: "To create and view application custom fields in Workable, follow these steps"
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   This guidance assumes that you have admin privileges for your Workable account.
@@ -154,7 +153,6 @@ import IntegrationFooter from "/snippets/integration-footer.mdx";
   </Step>
 </Steps>
 
-<IntegrationFooter />
 
 ## Useful Links
 

--- a/integration-configuration-concepts/ats/workday-application-custom-field.mdx
+++ b/integration-configuration-concepts/ats/workday-application-custom-field.mdx
@@ -3,7 +3,6 @@ title: "Workday Application Custom Field"
 description: "To create and view application custom field in Workday, follow these steps"
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   This guidance assumes that you have admin privileges for your Workday account.
@@ -120,4 +119,3 @@ import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 </Steps>
 
-<IntegrationFooter />

--- a/integration-configuration-concepts/ats/workday-assessment.mdx
+++ b/integration-configuration-concepts/ats/workday-assessment.mdx
@@ -3,7 +3,6 @@ title: "Workday Assessments"
 description: "To successfully manage candidate assessments in Workday and ensure seamless integration, follow this guide to configure your Workday account and perform the necessary actions."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 
 ## Applying for a Job on Behalf of a Candidate
@@ -194,7 +193,6 @@ To check the results of a completed assessment, go to the candidate's profile an
 </Frame>
 
 
-<IntegrationFooter />
 
 ## Useful Links
 <Card title="API Reference" icon="link" href="https://doc.workday.com/">

--- a/integration-configuration-concepts/ats/workday-background-check.mdx
+++ b/integration-configuration-concepts/ats/workday-background-check.mdx
@@ -3,7 +3,6 @@ title: "Workday Background Check"
 description: "Send invitations for background checks and verify results in Workday. This guide helps you manage the background check process for candidates."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 
 ## Submit a job application for the candidate in Workday
@@ -150,7 +149,6 @@ To access the _Job Application_, click on the candidate's name. Navigate to _Scr
 </Frame>
 
 
-<IntegrationFooter />
 
 ## Useful Links
 <Card title="API Reference" icon="link" href="https://doc.workday.com/">

--- a/integration-configuration-concepts/ats/workday-job-custom-field.mdx
+++ b/integration-configuration-concepts/ats/workday-job-custom-field.mdx
@@ -3,7 +3,6 @@ title: "Workday Job Custom Field"
 description: "To create job custom field in Workday, follow these steps"
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   This guidance assumes that you have admin privileges for your Workday account.
@@ -138,4 +137,3 @@ import IntegrationFooter from "/snippets/integration-footer.mdx";
     Note: Changes to Job Effective-Dated Custom Field values made through the API must be approved via the UI.
 </Note>
 
-<IntegrationFooter />

--- a/integration-configuration-concepts/ats/workday-rejected-reasons-configuration.mdx
+++ b/integration-configuration-concepts/ats/workday-rejected-reasons-configuration.mdx
@@ -3,7 +3,6 @@ title: "Workday Rejected Reasons Configuration"
 description: "To configure the rejected reasons in workday job applications"
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   This guidance assumes that you have admin privileges for your Workday account.

--- a/integration-configuration-concepts/hris/cascadehr-groups-mapping.mdx
+++ b/integration-configuration-concepts/hris/cascadehr-groups-mapping.mdx
@@ -3,7 +3,6 @@ title: "CascadeHR Groups/Locations Mapping Using the Hierarchy Endpoint"
 description: "Explanation of how locations, department groups, team groups, and top-level groups are mapped using the Hierarchy endpoint."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 - CascadeHR does not provide a dedicated API endpoint for retrieving lists of departments, teams, or locations.
 - These lists are also not directly accessible through the CascadeHR user interface. While departments can be viewed within the Payroll module, there is currently no API access to extract this information.

--- a/integration-configuration-concepts/hris/hibob-webhook-configurations.mdx
+++ b/integration-configuration-concepts/hris/hibob-webhook-configurations.mdx
@@ -3,7 +3,6 @@ title: "Hibob Time-off Webhook Configuration"
 description: "To successfully configure the webhook and send the event on action of time-off"
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   The following guidance assumes you have Admin privileges for your Hibob
@@ -65,7 +64,6 @@ import IntegrationFooter from "/snippets/integration-footer.mdx";
 </Steps>
 
 
-<IntegrationFooter />
 
 ## Useful Links
 <Card title="API Reference" icon="link" href="https://apidocs.hibob.com/reference/time-off-webhook-events">

--- a/integration-configuration-concepts/hris/workday-calculated-fields.mdx
+++ b/integration-configuration-concepts/hris/workday-calculated-fields.mdx
@@ -3,7 +3,6 @@ title: "Workday Calculated Fields"
 description: "To add calculated fields in Workday, follow these steps"
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   This guidance assumes that you have admin privileges for your Workday account.
@@ -82,4 +81,3 @@ import IntegrationFooter from "/snippets/integration-footer.mdx";
   </Step>
 </Steps>
 
-<IntegrationFooter />

--- a/integration-configuration-concepts/hris/workday-employee-custom-field.mdx
+++ b/integration-configuration-concepts/hris/workday-employee-custom-field.mdx
@@ -3,7 +3,6 @@ title: "Workday Employee Custom Field"
 description: "To create employee custom field in Workday, follow these steps"
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx";
 
 <Warning>
   This guidance assumes that you have admin privileges for your Workday account.
@@ -138,4 +137,3 @@ import IntegrationFooter from "/snippets/integration-footer.mdx";
     Note: Changes to Worker Effective-Dated Custom Field values made through the API must be approved via the UI.
 </Note>
 
-<IntegrationFooter />

--- a/integration-configuration-concepts/hris/workday-raas.mdx
+++ b/integration-configuration-concepts/hris/workday-raas.mdx
@@ -3,8 +3,6 @@ title: "Workday RaaS"
 description: "Follow these steps to configure and connect Workday via Report as a Service (RaaS) successfully."
 ---
 
-import IntegrationFooter from "/snippets/integration-footer.mdx"
-
 <Warning>
   This guidance assumes you have administrative privileges for your Workday account.
 </Warning>

--- a/snippets/integration-footer.mdx
+++ b/snippets/integration-footer.mdx
@@ -1,3 +1,0 @@
-<br />
-Congratulations, you're all set! If you face any issues with the steps mentioned above,
-please contact us by emailing integrations@stackone.com. We're always here to assist you!


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed the outdated `integrations@stackone.com` escalation from docs by deleting the `IntegrationFooter` import and component across all Hub docs (connection guides and integration configuration pages). This aligns the docs with current support channels and removes a redundant footer snippet.

<sup>Written for commit 3fe2a315930aa110bdad8f3c7a9cf4fc70e37db7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

