### PR TITLE
docs: add note about special character restrictions in Workday LMS credentials

### DIFF
--- a/connection-guides/lms/workdaylearning.mdx
+++ b/connection-guides/lms/workdaylearning.mdx
@@ -70,6 +70,10 @@ import IntegrationFooter from "/snippets/integration-footer.mdx";
   <Step title="Enter Account Information">
     Enter a username and password in the Account Information section on the "Create Integration System User" page.
 
+    <Note>
+      Workday doesn't allow certain special characters in the username and password. If you receive the error message "Could not validate credentials, please check your credentials and try again," this may be due to the use of unsupported special characters. Try using alphanumeric characters and common special characters like hyphens or underscores.
+    </Note>
+
     <Frame>
       <img className='rounded-md' style={{ margin: '0 auto', border: '1px solid #efefef' }} alt="Account Information" src="/images/workday/image6.png" />
     </Frame>

--- a/connection-guides/lms/workdaylearning.mdx
+++ b/connection-guides/lms/workdaylearning.mdx
@@ -71,7 +71,7 @@ import IntegrationFooter from "/snippets/integration-footer.mdx";
     Enter a username and password in the Account Information section on the "Create Integration System User" page.
 
     <Note>
-      Workday doesn't allow certain special characters in the username and password. If you receive the error message "Could not validate credentials, please check your credentials and try again," this may be due to the use of unsupported special characters. Try using alphanumeric characters and common special characters like hyphens or underscores.
+      If you receive the error message "Could not validate credentials, please check your credentials and try again," your username or password may include unsupported characters. As a troubleshooting step, try using only alphanumeric characters.
     </Note>
 
     <Frame>


### PR DESCRIPTION
Added a note in the Workday Learning documentation to inform users about special character restrictions in usernames and passwords.

This helps users avoid the "Could not validate credentials" error that can occur when using unsupported special characters in their credentials.

Fixes #384

---

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a troubleshooting note to the Workday Learning connection guide explaining that unsupported special characters in usernames or passwords can trigger the "Could not validate credentials, please check your credentials and try again" error. Recommends using only alphanumeric characters during integration user setup to avoid this issue (addresses #384).

<sup>Written for commit 243d0d17e0dba1048f1d860835f24dfee48db87e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

