### PR TITLE
ATS Workday Permissions and Scopes updates

### DIFF
--- a/connection-guides/ats/workday_OAuth2.mdx
+++ b/connection-guides/ats/workday_OAuth2.mdx
@@ -161,21 +161,24 @@ description: "If you've been directed to StackOne to integrate with Workday, the
     </Info>
     - Business Process Administration
     - Job Requisition Data
+    - Job Requisitions for Recruiting
     - Integration Build
     - Job Information
     - Job Profile: View
+    - Job Postings
+    - Manage: Organization Integration
+    - National ID Identification
     - Pre-Hire Data: Employment Agreement
     - Pre-Hire Personal Data
+    - Questionnaire
     - System Auditing
     - View: National Identifiers - All
     - **Candidate Data:**
-      - Other Information
-      - Photo
-      - Attachment
+      - Attachments
       - Personal Information
       - Job Application
-      - Job Requisitions
-      - Offer Details
+      - Other Information
+      - Offer Initiation
       - Other Jobs
     - **Person Data:**
       - Personal Data
@@ -184,20 +187,12 @@ description: "If you've been directed to StackOne to integrate with Workday, the
       - Date of Birth
       - Disabilities
       - Gender
-      - Government IDs
       - ID Information
       - Marital Status
-      - National ID Identification
       - Personal Information
       - Personal Photo
       - Home Address
-      - Home Email
-      - Home Phone
       - Work Address
-      - Work Email
-      - Work Phone
-    - **Manage:**
-      - Organization Integration
   </Step>
 </Steps>
 
@@ -278,6 +273,8 @@ description: "If you've been directed to StackOne to integrate with Workday, the
       - _Jobs & Positions_
       - _Organizations and Roles_
       - _Personal Data_
+      - _Pre-Hire Process_
+      - _Recruiting_
       - _Staffing_
       - _System_
       - _Tenant Non-Configurable_


### PR DESCRIPTION
<img width="1893" height="11590" alt="image" src="https://github.com/user-attachments/assets/cdeb0f5c-0b53-4420-b037-ec43ab3e3054" />


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update Workday ATS OAuth2 guide to match current Recruiting permissions and scopes. Clarifies required access, removes outdated entries, and adds missing categories.

- **Refactors**
  - Added: Job Requisitions for Recruiting, Job Postings, Questionnaire, National ID Identification, Manage: Organization Integration.
  - Candidate Data: standardized "Attachments", replaced "Offer Details" with "Offer Initiation", removed "Photo", moved job requisition access under recruiting.
  - Person Data: removed Government IDs and personal/work contact emails/phones; moved National ID Identification to top level.
  - Categories: added Pre‑Hire Process and Recruiting.

<sup>Written for commit a30f014fb03e33132e28fbe9899e0a509a4ac385. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

