### PR TITLE
chore(seo): disable search engine indexing for all hub docs pages

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -8,6 +8,11 @@
     "dark": "#0D9373"
   },
   "favicon": "/favicon.svg",
+  "seo": {
+    "metatags": {
+      "robots": "noindex, nofollow"
+    }
+  },
   "navigation": {
     "pages": [
       "integrations",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Prevents search engines from indexing any page of the Hub documentation by adding a global `robots: noindex, nofollow` meta tag via the Mintlify `docs.json` config.

## Changes

- `docs.json`: added top-level `seo.metatags.robots: "noindex, nofollow"`.

With this setting, Mintlify injects the robots meta tag on every rendered page of the site, so all pages (including every connection guide, redirect target, and top-level page) are excluded from search engine indexes.

## References

- Mintlify SEO docs: https://mintlify.com/docs/optimize/seo#disable-indexing
  > You can also specify `noindex` for all pages in your docs by setting the `metatags.robots` field to `"noindex"` in your `docs.json`.

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://stackonehq.slack.com/archives/D093NBXS9C1/p1773185466164529?thread_ts=1773185466.164529&cid=D093NBXS9C1)

<div><a href="https://cursor.com/agents/bc-ee833ec9-b402-5a19-bf3b-1adba0856078"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ee833ec9-b402-5a19-bf3b-1adba0856078"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable search engine indexing for all Hub docs by setting `seo.metatags.robots: "noindex, nofollow"` in `docs.json`, which makes Mintlify inject the robots meta tag on every page.

<sup>Written for commit 7efb83d6123120be5907f350fc1c3b2f6c85d495. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

