### PR TITLE
docs: update HiBob webhook endpoint URL wording

### DIFF
--- a/integration-configuration-concepts/hris/hibob-webhook-configurations.mdx
+++ b/integration-configuration-concepts/hris/hibob-webhook-configurations.mdx
@@ -42,7 +42,7 @@ description: "To successfully configure the webhook and send the event on action
   <Step title="Webhook Configurations">
     Please provide the required details to configure the webhook for `time-off` events:
     - **Name**: Enter the webhook name.
-    - **Endpoint URL**: Use the base URL provided by the partner and append your external trigger token from StackOne Hub as follows:
+    - **Endpoint URL**: Use the following base URL and append your external trigger token from StackOne Hub as follows:
       `https://api.stackone.com/external-trigger/hibob?externalTriggerToken=<Your_External_Trigger_Token>`
     - **Version**: Select the webhook version.
     - **Events**: Choose the time-off event types.


### PR DESCRIPTION
Changed 'Use the base URL provided by the partner' to 'Use the following base URL' for clarity in the webhook configuration instructions.

Fixes #389

---

Generated with [Claude Code](https://claude.ai/code)