### PR TITLE
docs: document customCourseTypes field for SAP SuccessFactors LMS connector

### DIFF
--- a/connection-guides/lms/sapsuccessfactors.mdx
+++ b/connection-guides/lms/sapsuccessfactors.mdx
@@ -109,11 +109,11 @@ flow you follow will depend on your use case.
 
 By default, StackOne classifies SAP items with the types `COURSE`, `MOOC`, or `ONLINE` as courses, and everything else (`BOOK`, `VIDEO`, `DOC`, etc.) as content.
 
-If your SAP instance uses its own custom item classification types for what you consider courses (for example, a custom type like `PROGRAM` or `WEBINAR`), those items won't appear in the StackOne `/courses` endpoint by default, since StackOne doesn't recognize your custom type names.
+If your SAP instance uses its own custom item classification types for what you consider courses (for example, a custom type like `PROGRAM` or `WEBINAR`), those items won't appear in the StackOne `/courses` endpoint by default, since StackOne doesn't recognize your custom type codes.
 
 To fix this, enter your custom SAP item type codes as a comma-separated list in the `Custom Course Content Types` field when connecting SAP SuccessFactors to StackOne (for example: `PROGRAM,WEBINAR`). These are added on top of the standard `COURSE`, `MOOC`, and `ONLINE` types — items matching any of them will be returned from `/courses`, and none of them will appear in `/content`.
 
-You can find your instance's item type IDs in SAP SuccessFactors Learning Administration, under the classification/type configuration for the content or course you're trying to sync.
+You can find your instance's item type codes in SAP SuccessFactors Learning Administration, under the classification/type configuration for the content or course you're trying to sync.
 
 # Authentication Flow 2: Linking your SAP instance library to an external content provider pushing data to your SAP instance.
 

--- a/connection-guides/lms/sapsuccessfactors.mdx
+++ b/connection-guides/lms/sapsuccessfactors.mdx
@@ -111,7 +111,7 @@ By default, StackOne classifies SAP items with the type `COURSE`, `MOOC`, or `ON
 
 If your SAP instance uses its own custom item classification types for what you consider courses (for example, a custom type like `PROGRAM` or `WEBINAR`), those items won't appear in the StackOne `/courses` endpoint by default, since StackOne doesn't recognize your custom type names.
 
-To fix this, enter your custom SAP item type IDs as a comma-separated list in the `Custom Course Content Types` field when connecting SAP SuccessFactors to StackOne (for example: `PROGRAM,WEBINAR`). These are added on top of the standard `COURSE`, `MOOC`, and `ONLINE` types — items matching any of them will be returned from `/courses`, and none of them will appear in `/content`.
+To fix this, enter your custom SAP item type codes as a comma-separated list in the `Custom Course Content Types` field when connecting SAP SuccessFactors to StackOne (for example: `PROGRAM,WEBINAR`). These are added on top of the standard `COURSE`, `MOOC`, and `ONLINE` types — items matching any of them will be returned from `/courses`, and none of them will appear in `/content`.
 
 You can find your instance's item type IDs in SAP SuccessFactors Learning Administration, under the classification/type configuration for the content or course you're trying to sync.
 

--- a/connection-guides/lms/sapsuccessfactors.mdx
+++ b/connection-guides/lms/sapsuccessfactors.mdx
@@ -107,7 +107,7 @@ flow you follow will depend on your use case.
 
 ## Configuring Custom Course Content Types (Optional)
 
-By default, StackOne classifies SAP items with the type `COURSE`, `MOOC`, or `ONLINE` as courses, and everything else (`BOOK`, `VIDEO`, `DOC`, etc) as content.
+By default, StackOne classifies SAP items with the types `COURSE`, `MOOC`, or `ONLINE` as courses, and everything else (`BOOK`, `VIDEO`, `DOC`, etc.) as content.
 
 If your SAP instance uses its own custom item classification types for what you consider courses (for example, a custom type like `PROGRAM` or `WEBINAR`), those items won't appear in the StackOne `/courses` endpoint by default, since StackOne doesn't recognize your custom type names.
 

--- a/connection-guides/lms/sapsuccessfactors.mdx
+++ b/connection-guides/lms/sapsuccessfactors.mdx
@@ -105,6 +105,16 @@ flow you follow will depend on your use case.
   </Step>
 </Steps>
 
+## Configuring Custom Course Content Types (Optional)
+
+By default, StackOne classifies SAP items with the type `COURSE`, `MOOC`, or `ONLINE` as courses, and everything else (`BOOK`, `VIDEO`, `DOC`, etc) as content.
+
+If your SAP instance uses its own custom item classification types for what you consider courses (for example, a custom type like `PROGRAM` or `WEBINAR`), those items won't appear in the StackOne `/courses` endpoint by default, since StackOne doesn't recognize your custom type names.
+
+To fix this, enter your custom SAP item type IDs as a comma-separated list in the `Custom Course Content Types` field when connecting SAP SuccessFactors to StackOne (for example: `PROGRAM,WEBINAR`). These are added on top of the standard `COURSE`, `MOOC`, and `ONLINE` types — items matching any of them will be returned from `/courses`, and none of them will appear in `/content`.
+
+You can find your instance's item type IDs in SAP SuccessFactors Learning Administration, under the classification/type configuration for the content or course you're trying to sync.
+
 # Authentication Flow 2: Linking your SAP instance library to an external content provider pushing data to your SAP instance.
 
 ### Finding the Learning Hub URL


### PR DESCRIPTION
## Summary
- Documents the new `Custom Course Content Types` setup field (unified-cloud-api PR: StackOneHQ/unified-cloud-api#8481) under Authentication Flow 1 of the SAP SuccessFactors LMS connection guide.
- Explains when a T2 needs it (custom SAP item classification types not recognized as courses) and the expected comma-separated format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)