### PR TITLE
UKG Pro WFM: require manager-level integration user for time-off

### DIFF
--- a/connection-guides/hris/ukgprowfm.mdx
+++ b/connection-guides/hris/ukgprowfm.mdx
@@ -26,11 +26,23 @@ UKG Pro Workforce Management uses an OAuth LDAP (password-based) flow. You'll ne
     - **Client Secret**
   </Step>
 
-  <Step title="Prepare a username and password">
-    Use a dedicated integration user where possible. Make sure you have:
-    
+  <Step title="Prepare a dedicated integration user">
+    Use a dedicated integration user with manager-level permissions. StackOne creates and manages time-off requests on behalf of your employees, which UKG treats as a manager action. Make sure the user has:
+
     - **Username**
     - **Password**
+
+    Grant the integration user:
+
+    - A manager Function Access Profile that allows managing employee time-off requests (create and edit).
+    - A Manager Role with an employee group (Hyperfind) covering every employee you want to manage time-off for. Employees outside this scope are rejected.
+    - Data access to those same employees.
+
+    If time-off requests should be approved automatically instead of left pending, enable Auto Approval on the relevant time-off request subtype.
+
+    <Note>
+      The exact profile, role, and access-point names vary by UKG tenant and version. Ask your UKG admin to grant the integration user manager-level time-off permissions covering the employees in scope.
+    </Note>
   </Step>
 </Steps>
 


### PR DESCRIPTION
## What

Updates the UKG Pro WFM connection guide credential step to require a dedicated integration user with **manager-level permissions**, and adds a `<Note>` that exact profile/role/access-point names are tenant-specific.

## Why

The UKG Pro WFM time-off `create` in the connector is moving from the employee self-service endpoint (`POST /v1/scheduling/employee_timeoff`) to the manager endpoint (`POST /v1/scheduling/timeoff`), so requests are created for the target employee instead of as the connected service user. The manager endpoint checks manager scope, so a plain integration user fails against it. The guide previously listed only credential fields and never stated the required permissions, so customers following it as-is would still hit a permission failure after the connector fix ships.

## Scope

- Only the "Prepare a username and password" step changed (now "Prepare a dedicated integration user").
- Host, Client ID/Secret, linking steps, and Available data sections untouched.
- Wording kept general per the ticket, with no invented tenant-specific UKG UI labels; specifics pushed to the customer's UKG admin.

Ticket: INT-8679